### PR TITLE
Fix issue 18 + fixes + polishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Change Log
 
-## [0.7.2] 2020-04-10
+## [0.7.2] 2020-04-12
 
 - Fix error [#18 _(codeAction failed with message: Cannot read property 'split' of undefined)_](https://github.com/nvuillam/vscode-groovy-lint/issues/18)
 - Add more automated tests for CodeActions
 - Display a waiting info message when a Lint Folder request takes more than 5 seconds + allow to cancel the current operation
 - Fix perf issue when closing all visible text editors
-
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.1.0
+  - Upgrade to [Groovy 3.0.3](https://dl.bintray.com/groovy/maven/apache-groovy-binary-3.0.3.zip)
+  
 ### [0.7.1] 2020-04-09
 
 - Add setting **groovyLint.debug.enable** : Display more logs in VsCode Output panel (select "GroovyLint") for issue investigation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.7.2] 2020-04-10
+
+- Fix error [#18 _(codeAction failed with message: Cannot read property 'split' of undefined)_](https://github.com/nvuillam/vscode-groovy-lint/issues/18)
+- Add more automated tests for CodeActions
+- Display a waiting info message when a Lint Folder request takes more than 5 seconds + allow to cancel the current operation
+- Fix perf issue when closing all visible text editors
+
 ### [0.7.1] 2020-04-09
 
 - Add setting **groovyLint.debug.enable** : Display more logs in VsCode Output panel (select "GroovyLint") for issue investigation

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Formatting and Auto-fix are still in beta version, please post an [issue](https:
 |---------------------------------|------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
 | **Analyze code**                | Lint the code of the current tab                                                               | Ctrl+Shit+F9<br/>Contextual</br>Status bar<br/>Commands                                                  |
 | **Format**                      | Format the code of the current tab                                                             | Shift+Alt+F<br/>Contextual</br>Commands                                                                  |
-| **Fix all errors**              | Fix the code of the current tab                                                                | Contextual</br>Commands                                                                |
+| **Fix all errors**              | Fix the code of the current tab                                                                | Contextual</br>Commands                                                                                  |
 | **Lint folder**                 | Lint all applicable files of a folder                                                          | Contextual                                                                                               |
 | Fix single error                | Apply quick fix for a single error                                                             | Quick Fix<br/>Diagnostic                                                                                 |
 | Fix _errorType_ in entire file  | Apply quick fix for all errors of the same type in the currrent tab                            | Quick Fix<br/>Diagnostic                                                                                 |
@@ -67,10 +67,14 @@ Please follow [Contribution instructions](https://github.com/nvuillam/vscode-gro
 
 ## Release Notes
 
-## [0.7.2] 2020-04-10
+## [0.7.2] 2020-04-12
 
 - Fix error [#18 _(codeAction failed with message: Cannot read property 'split' of undefined)_](https://github.com/nvuillam/vscode-groovy-lint/issues/18)
+- Add more automated tests for CodeActions
 - Display a waiting info message when a Lint Folder request takes more than 5 seconds + allow to cancel the current operation
+- Fix perf issue when closing all visible text editors
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.1.0
+  - Upgrade to [Groovy 3.0.3](https://dl.bintray.com/groovy/maven/apache-groovy-binary-3.0.3.zip)
 
 ### [0.7.1] 2020-04-09
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ Please follow [Contribution instructions](https://github.com/nvuillam/vscode-gro
 
 ## Release Notes
 
+## [0.7.2] 2020-04-10
+
+- Fix error [#18 _(codeAction failed with message: Cannot read property 'split' of undefined)_](https://github.com/nvuillam/vscode-groovy-lint/issues/18)
+- Display a waiting info message when a Lint Folder request takes more than 5 seconds + allow to cancel the current operation
+
 ### [0.7.1] 2020-04-09
 
 - Add setting **groovyLint.debug.enable** : Display more logs in VsCode Output panel (select "GroovyLint") for issue investigation

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -41,8 +41,8 @@ suite('VsCode GroovyLint Test Suite', async () => {
 	vscode.window.showInformationMessage('Start all VsCode Groovy Lint tests');
 
 	// Check extension is available
-	test("1.0 GroovyLint extension is available", async () => {
-		console.log("Start 1.0 GroovyLint extension is available");
+	test("1.0.0 GroovyLint extension is available", async () => {
+		console.log("Start 1.0.0 GroovyLint extension is available");
 		testDocs['bigGroovy'].doc = await openDocument('bigGroovy');
 		console.log(JSON.stringify(testDocs, null, 2));
 		const availableExtensions = vscode.extensions.all.map(ext => ext.id);
@@ -52,8 +52,8 @@ suite('VsCode GroovyLint Test Suite', async () => {
 	}).timeout(10000);
 
 	// Check all commands are here
-	test("1.1 Check GroovyLint VsCode commands", async () => {
-		console.log("Start 1.1 Check GroovyLint VsCode commands");
+	test("1.1.0 Check GroovyLint VsCode commands", async () => {
+		console.log("Start 1.1.0 Check GroovyLint VsCode commands");
 		const allCommands = await vscode.commands.getCommands();
 		debug('Commands found: ' + JSON.stringify(allCommands));
 		const groovyLintCommands = allCommands.filter((command) => {
@@ -63,8 +63,8 @@ suite('VsCode GroovyLint Test Suite', async () => {
 	}).timeout(5000);
 
 	// Lint document
-	test("2.0 Lint big document", async () => {
-		console.log("Start 2.0 Lint big document");
+	test("2.0.0 Lint big document", async () => {
+		console.log("Start 2.0.0 Lint big document");
 		await waitUntil(() => diagnosticsChanged(testDocs['bigGroovy'].doc.uri, []), 100000);
 		const docDiagnostics = vscode.languages.getDiagnostics(testDocs['bigGroovy'].doc.uri);
 
@@ -72,11 +72,11 @@ suite('VsCode GroovyLint Test Suite', async () => {
 	}).timeout(120000);
 
 	// Format document without updating diagnostics
-	test("2.1. Format big document", async () => {
-		console.log("Start 2.1. Format big document");
+	test("2.1.0 Format big document", async () => {
+		console.log("Start 2.1.0 Format big document");
 		const textBefore = getActiveEditorText();
 		const prevDiags = vscode.languages.getDiagnostics(testDocs['bigGroovy'].doc.uri);
-		const textEdits = await vscode.commands.executeCommand('vscode.executeFormatDocumentProvider', testDocs['bigGroovy'].doc.uri, {});
+		const textEdits = await executeCommand('vscode.executeFormatDocumentProvider', testDocs['bigGroovy'].doc.uri, {});
 		await applyTextEditsOnDoc(testDocs['bigGroovy'].doc.uri, textEdits as vscode.TextEdit[]);
 		await waitUntil(() => diagnosticsChanged(testDocs['bigGroovy'].doc.uri, prevDiags), 100000); // Wait for linter to lint again after fix
 		const textAfter = getActiveEditorText();
@@ -85,11 +85,11 @@ suite('VsCode GroovyLint Test Suite', async () => {
 	}).timeout(120000);
 
 	// Fix document
-	test("2.2. Fix big document", async () => {
-		console.log("Start 2.2. Fix big document");
+	test("2.2.0 Fix big document", async () => {
+		console.log("Start 2.2.0 Fix big document");
 		const textBefore = getActiveEditorText();
 		const prevDiags = vscode.languages.getDiagnostics(testDocs['bigGroovy'].doc.uri);
-		vscode.commands.executeCommand('groovyLint.lintFix');
+		executeCommand('groovyLint.lintFix', testDocs['bigGroovy'].doc.uri);
 		await waitUntil(() => documentHasBeenUpdated(testDocs['bigGroovy'].doc.uri, textBefore), 100000);
 		await waitUntil(() => diagnosticsChanged(testDocs['bigGroovy'].doc.uri, []), 100000);
 		const docDiagnostics = vscode.languages.getDiagnostics(testDocs['bigGroovy'].doc.uri);
@@ -100,8 +100,8 @@ suite('VsCode GroovyLint Test Suite', async () => {
 	}).timeout(200000);
 
 	// Lint tiny document
-	test("3.0 Lint tiny document", async () => {
-		console.log("Start 3.0 Lint tiny document");
+	test("3.0.0 Lint tiny document", async () => {
+		console.log("Start 3.0.0 Lint tiny document");
 		testDocs['tinyGroovy'].doc = await openDocument('tinyGroovy');
 		await waitUntil(() => diagnosticsChanged(testDocs['tinyGroovy'].doc.uri, []), 60000);
 		const docDiagnostics = vscode.languages.getDiagnostics(testDocs['tinyGroovy'].doc.uri);
@@ -109,11 +109,39 @@ suite('VsCode GroovyLint Test Suite', async () => {
 		assert(docDiagnostics.length === numberOfDiagnosticsForTinyGroovyLint, `${numberOfDiagnosticsForTinyGroovyLint} GroovyLint diagnostics found after lint (${docDiagnostics.length} returned)`);
 	}).timeout(60000);
 
-	// Format tiny document
-	test("3.1. Format tiny document", async () => {
-		console.log("Start 3.1. Format tiny document");
+	// Quick fix error
+	test("3.0.1 Quick fix an error in tiny document", async () => {
+		console.log("Start 3.0.1 Quick fix an error in tiny document");
 		const textBefore = getActiveEditorText();
-		const textEdits = await vscode.commands.executeCommand('vscode.executeFormatDocumentProvider', testDocs['tinyGroovy'].doc.uri, {});
+		const docDiagnostics = vscode.languages.getDiagnostics(testDocs['tinyGroovy'].doc.uri);
+		const diagnostic = docDiagnostics.filter(diag => (diag.code as string).startsWith('Indentation'))[0];
+		const cmdArgs = [diagnostic, testDocs['tinyGroovy'].doc.uri];
+		executeCommand('groovyLint.quickFix', cmdArgs);
+		await waitUntil(() => documentHasBeenUpdated(testDocs['tinyGroovy'].doc.uri, textBefore), 60000);
+		const textAfter = getActiveEditorText();
+
+		assert(textBefore !== textAfter, 'TextDocument text must be updated after format');
+	}).timeout(30000);
+
+	// Quick fix all error types
+	test("3.0.2 Quick fix and error type in tiny document", async () => {
+		console.log("Start 3.0.2 Quick fix and error type in tiny document");
+		const textBefore = getActiveEditorText();
+		const docDiagnostics = vscode.languages.getDiagnostics(testDocs['tinyGroovy'].doc.uri);
+		const diagnostic = docDiagnostics.filter(diag => (diag.code as string).startsWith('Indentation'))[0];
+		const cmdArgs = [diagnostic, testDocs['tinyGroovy'].doc.uri];
+		executeCommand('groovyLint.quickFixFile', cmdArgs);
+		await waitUntil(() => documentHasBeenUpdated(testDocs['tinyGroovy'].doc.uri, textBefore), 60000);
+		const textAfter = getActiveEditorText();
+
+		assert(textBefore !== textAfter, 'TextDocument text must be updated after format');
+	}).timeout(30000);
+
+	// Format tiny document
+	test("3.1.0 Format tiny document", async () => {
+		console.log("Start 3.1.0 Format tiny document");
+		const textBefore = getActiveEditorText();
+		const textEdits = await executeCommand('vscode.executeFormatDocumentProvider', testDocs['tinyGroovy'].doc.uri, {});
 		await applyTextEditsOnDoc(testDocs['tinyGroovy'].doc.uri, textEdits as vscode.TextEdit[]);
 		await sleepPromise(5000);
 		const textAfter = getActiveEditorText();
@@ -121,12 +149,12 @@ suite('VsCode GroovyLint Test Suite', async () => {
 		assert(textBefore !== textAfter, 'TextDocument text must be updated after format');
 	}).timeout(30000);
 
-	// Fix document
-	test("3.2. Fix tiny document", async () => {
-		console.log("Start 3.2. Fix tiny document");
+	// Fix tiny document
+	test("3.2.0 Fix tiny document", async () => {
+		console.log("Start 3.2.0 Fix tiny document");
 		const textBefore = getActiveEditorText();
 		const prevDiags = vscode.languages.getDiagnostics(testDocs['tinyGroovy'].doc.uri);
-		vscode.commands.executeCommand('groovyLint.lintFix');
+		executeCommand('groovyLint.lintFix');
 		await waitUntil(() => documentHasBeenUpdated(testDocs['tinyGroovy'].doc.uri, textBefore), 60000);
 		await waitUntil(() => diagnosticsChanged(testDocs['tinyGroovy'].doc.uri, prevDiags), 60000);
 		const docDiagnostics = vscode.languages.getDiagnostics(testDocs['tinyGroovy'].doc.uri);
@@ -137,8 +165,8 @@ suite('VsCode GroovyLint Test Suite', async () => {
 	}).timeout(60000);
 
 	// Lint Jenkinsfile
-	test("4.0 Lint Jenkinsfile", async () => {
-		console.log("Start 4.0 Lint Jenkinsfile");
+	test("4.0.0 Lint Jenkinsfile", async () => {
+		console.log("Start 4.0.0 Lint Jenkinsfile");
 		testDocs['Jenkinsfile'].doc = await openDocument('Jenkinsfile');
 		await waitUntil(() => diagnosticsChanged(testDocs['Jenkinsfile'].doc.uri, []), 60000);
 		const docDiagnostics = vscode.languages.getDiagnostics(testDocs['Jenkinsfile'].doc.uri);
@@ -148,11 +176,11 @@ suite('VsCode GroovyLint Test Suite', async () => {
 
 
 	// Format Jenkinsfile
-	test("4.1. Format Jenkinsfile", async () => {
-		console.log("Start 4.1. Format Jenkinsfile");
+	test("4.1.0 Format Jenkinsfile", async () => {
+		console.log("Start 4.1.0 Format Jenkinsfile");
 		const textBefore = getActiveEditorText();
 		const prevDiags = vscode.languages.getDiagnostics(testDocs['Jenkinsfile'].doc.uri);
-		const textEdits = await vscode.commands.executeCommand('vscode.executeFormatDocumentProvider', testDocs['Jenkinsfile'].doc.uri, {});
+		const textEdits = await executeCommand('vscode.executeFormatDocumentProvider', testDocs['Jenkinsfile'].doc.uri, {});
 		await applyTextEditsOnDoc(testDocs['Jenkinsfile'].doc.uri, textEdits as vscode.TextEdit[]);
 		await waitUntil(() => diagnosticsChanged(testDocs['Jenkinsfile'].doc.uri, prevDiags), 100000); // Wait for linter to lint again after fix
 		const textAfter = getActiveEditorText();
@@ -161,10 +189,10 @@ suite('VsCode GroovyLint Test Suite', async () => {
 	}).timeout(100000);
 
 	// Fix Jenkinsfile (no errors fixed)
-	test("4.2. Fix Jenkinsfile", async () => {
-		console.log("Start 4.2. Fix Jenkinsfile");
+	test("4.2.0 Fix Jenkinsfile", async () => {
+		console.log("Start 4.2.0 Fix Jenkinsfile");
 		const textBefore = getActiveEditorText();
-		vscode.commands.executeCommand('groovyLint.lintFix');
+		executeCommand('groovyLint.lintFix');
 		await waitUntil(() => diagnosticsChanged(testDocs['Jenkinsfile'].doc.uri, []), 100000);
 		const docDiagnostics = vscode.languages.getDiagnostics(testDocs['Jenkinsfile'].doc.uri);
 		assert(docDiagnostics.length === numberOfDiagnosticsForJenkinsfileLintFix, `${numberOfDiagnosticsForJenkinsfileLintFix} GroovyLint diagnostics found after lint (${docDiagnostics.length} returned)`);
@@ -172,15 +200,17 @@ suite('VsCode GroovyLint Test Suite', async () => {
 
 
 	// Lint a folder
-	test("5.1. Lint folder", async () => {
-		console.log("4.1. Lint folder");
+	test("5.1.0 Lint folder", async () => {
+		console.log("5.1.0 Lint folder");
 		const docFolderUri = vscode.Uri.file(
 			path.join(__dirname + testFolderExamplesLocation)
 		);
+
+		// Lint folder
 		const bigGroovyUri = testDocs['bigGroovy'].doc.uri;
 		const tinyGroovyUri = testDocs['tinyGroovy'].doc.uri;
 		const JenkinsfileUri = testDocs['Jenkinsfile'].doc.uri;
-		await vscode.commands.executeCommand('groovyLint.lintFolder', [docFolderUri]);
+		await executeCommand('groovyLint.lintFolder', [docFolderUri]);
 		await waitUntil(() => diagnosticsChanged(bigGroovyUri, []), 120000);
 		await waitUntil(() => diagnosticsChanged(tinyGroovyUri, []), 60000);
 		await waitUntil(() => diagnosticsChanged(JenkinsfileUri, []), 120000);
@@ -194,10 +224,39 @@ suite('VsCode GroovyLint Test Suite', async () => {
 
 		assert(totalDiags === numberOfDiagnosticsForFolderLint, `${numberOfDiagnosticsForFolderLint} GroovyLint diagnostics found after lint (${totalDiags} returned)`);
 	}).timeout(180000);
+
+	/*
+	// Close folders
+	test("6.1.0 Close tabs", async () => {
+		// Close all open tabs
+		await executeCommand('workbench.action.closeAllEditors');
+		console.log(`Closed all editors`);
+		await sleepPromise(5000);
+
+		const numberOpenEditors = vscode.window.visibleTextEditors.length;
+		assert(numberOpenEditors === 0, `0 open editors after close all (${numberOpenEditors} returned \n${JSON.stringify(vscode.window.visibleTextEditors)})`);
+
+	}).timeout(180000); */
 });
 
+// Execute VsCode command
+async function executeCommand(command: string, args: any = null, opts: any = null): Promise<any> {
+
+	if (args && opts) {
+		console.log(`Execute command ${command} with args ${JSON.stringify(args)} and options ${JSON.stringify(opts)}`);
+		return vscode.commands.executeCommand(command, args, opts);
+	}
+	else if (args) {
+		console.log(`Execute command ${command} with args ${JSON.stringify(args)}`);
+		return vscode.commands.executeCommand(command, args);
+	} else {
+		console.log(`Execute command ${command}`);
+		return vscode.commands.executeCommand(command);
+	}
+}
+
 // Open a textDocument and show it in editor
-async function openDocument(docExample: string) {
+async function openDocument(docExample: string): Promise<vscode.TextDocument> {
 	const docName = testDocs[docExample].path;
 	const docUri = vscode.Uri.file(
 		path.join(__dirname + testFolderExamplesLocation + docName)
@@ -212,7 +271,7 @@ function getActiveEditorText() {
 	return vscode.window.activeTextEditor.document.getText();
 }
 
-async function applyTextEditsOnDoc(docUri: vscode.Uri, textEdits: vscode.TextEdit[]) {
+async function applyTextEditsOnDoc(docUri: vscode.Uri, textEdits: vscode.TextEdit[]): Promise<any> {
 	const workspaceEdit = new vscode.WorkspaceEdit();
 	workspaceEdit.set(docUri, textEdits);
 	const applyRes = await vscode.workspace.applyEdit(workspaceEdit);
@@ -269,7 +328,7 @@ function diagnosticsChanged(docUri: vscode.Uri, prevDiags: vscode.Diagnostic[]):
 	});
 }
 
-async function groovyLintExtensionIsActive() {
+async function groovyLintExtensionIsActive(): Promise<boolean> {
 	const allCommands = await vscode.commands.getCommands(true);
 	return allCommands.includes('groovyLint.lint');
 }
@@ -283,10 +342,10 @@ function documentHasBeenUpdated(docUri: vscode.Uri, prevDocSource: string): Prom
 }
 
 // Check if the only diagnostic is the waiting one
-function isWaitingDiagnostic(diags: vscode.Diagnostic[]) {
+function isWaitingDiagnostic(diags: vscode.Diagnostic[]): boolean {
 	return diags && diags.length === 1 && diags[0].code === 'GroovyLintWaiting';
 }
 
-async function sleepPromise(ms: number) {
+async function sleepPromise(ms: number): Promise<any> {
 	await new Promise(r => setTimeout(r, ms));
 }

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -118,6 +118,7 @@ suite('VsCode GroovyLint Test Suite', async () => {
 		const cmdArgs = [diagnostic, testDocs['tinyGroovy'].doc.uri];
 		executeCommand('groovyLint.quickFix', cmdArgs);
 		await waitUntil(() => documentHasBeenUpdated(testDocs['tinyGroovy'].doc.uri, textBefore), 60000);
+		await sleepPromise(5000);
 		const textAfter = getActiveEditorText();
 
 		assert(textBefore !== textAfter, 'TextDocument text must be updated after format');
@@ -132,6 +133,7 @@ suite('VsCode GroovyLint Test Suite', async () => {
 		const cmdArgs = [diagnostic, testDocs['tinyGroovy'].doc.uri];
 		executeCommand('groovyLint.quickFixFile', cmdArgs);
 		await waitUntil(() => documentHasBeenUpdated(testDocs['tinyGroovy'].doc.uri, textBefore), 60000);
+		await sleepPromise(5000);
 		const textAfter = getActiveEditorText();
 
 		assert(textBefore !== textAfter, 'TextDocument text must be updated after format');

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -498,9 +498,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "npm-groovy-lint": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-4.0.0.tgz",
-      "integrity": "sha512-mL+8xo5/M8aQ3O0DzMWhwRYc+Y68hYvE1Oa/46Bsy8E17FmiDlHcDEtSjbcwvnJa29CHSnjfZfvTp/MgTWfafg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-4.1.0.tgz",
+      "integrity": "sha512-CDFEZr6ApVo63Es7eTVshyI+hrIjPqLIgZ4xxAwk9TE8NGU0d1ZOudTt0oeD8/coNfrw9OnoU2sC0nkBhpSaHw==",
       "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1",
@@ -692,9 +692,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.2.1.tgz",
-      "integrity": "sha512-aHhm1pD02jXXkyIpq25qBZjr3CQgg8KST8uX0OWXch3xE6jw+1bfbWnCjzMwojsTquroUmKFHNzU6x26mEiRxw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.2.2.tgz",
+      "integrity": "sha512-Zo84u6o2PebMSK3zjJ6Zp5wi8VnQZnEaCP13Ul/lt1ANsLACxnJxq4EEm1PY94/por1Hm9+7xpIswdS5AkieMA==",
       "dev": true
     },
     "shelljs": {

--- a/server/package.json
+++ b/server/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",
-    "npm-groovy-lint": "^4.0.0",
+    "npm-groovy-lint": "^4.1.0",
     "vscode-languageserver-textdocument": "^1.0.1"
   }
 }

--- a/server/src/DocumentsManager.ts
+++ b/server/src/DocumentsManager.ts
@@ -69,27 +69,27 @@ export class DocumentsManager {
 		}
 		// Command: Apply quick fix
 		else if (params.command === 'groovyLint.quickFix') {
-			const [diagnostic, textDocumentUri] = params.arguments!;
+			const [textDocumentUri, diagnostic] = params.arguments!;
 			await applyQuickFixes([diagnostic], textDocumentUri, this);
 		}
 		// Command: Apply quick fix in all file
 		else if (params.command === 'groovyLint.quickFixFile') {
-			const [diagnostic, textDocumentUri] = params.arguments!;
+			const [textDocumentUri, diagnostic] = params.arguments!;
 			await applyQuickFixesInFile([diagnostic], textDocumentUri, this);
 		}
 		// NV: not working yet 
 		else if (params.command === 'groovyLint.addSuppressWarning') {
-			const [diagnostic, textDocumentUri] = params.arguments!;
+			const [textDocumentUri, diagnostic] = params.arguments!;
 			await addSuppressWarning(diagnostic, textDocumentUri, 'line', this);
 		}
 		// NV: not working yet 
 		else if (params.command === 'groovyLint.addSuppressWarningFile') {
-			const [diagnostic, textDocumentUri] = params.arguments!;
+			const [textDocumentUri, diagnostic] = params.arguments!;
 			await addSuppressWarning(diagnostic, textDocumentUri, 'file', this);
 		}
 		// Command: Update .groovylintrc.json to ignore error in the future
 		else if (params.command === 'groovyLint.alwaysIgnoreError') {
-			const [diagnostic, textDocumentUri] = params.arguments!;
+			const [textDocumentUri, diagnostic] = params.arguments!;
 			await alwaysIgnoreError(diagnostic, textDocumentUri, this);
 		}
 		// Show rule documentation
@@ -107,6 +107,10 @@ export class DocumentsManager {
 	// Return TextDocument from uri
 	getDocumentFromUri(docUri: string, setCurrent = false): TextDocument {
 		const textDocument = this.documents.get(docUri)!;
+		// eslint-disable-next-line eqeqeq
+		if (textDocument == null) {
+			throw new Error(`ERROR: Document not found for URI ${docUri}`);
+		}
 		if (setCurrent) {
 			this.setCurrentDocumentUri(docUri);
 		}

--- a/server/src/codeActions.ts
+++ b/server/src/codeActions.ts
@@ -64,7 +64,7 @@ function createQuickFixCodeActions(diagnostic: Diagnostic, quickFix: any, textDo
 		command: {
 			command: 'groovyLint.quickFix',
 			title: quickFix.label,
-			arguments: [diagnostic, textDocumentUri]
+			arguments: [textDocumentUri, diagnostic]
 		},
 		diagnostics: [diagnostic],
 		isPreferred: true
@@ -79,7 +79,7 @@ function createQuickFixCodeActions(diagnostic: Diagnostic, quickFix: any, textDo
 		command: {
 			command: 'groovyLint.quickFixFile',
 			title: `${quickFix.label} in the entire file`,
-			arguments: [diagnostic, textDocumentUri]
+			arguments: [textDocumentUri, diagnostic]
 		},
 		diagnostics: [diagnostic],
 		isPreferred: true
@@ -139,7 +139,7 @@ function createIgnoreActions(diagnostic: Diagnostic, textDocumentUri: string): C
 			command: {
 				command: 'groovyLint.alwaysIgnoreError',
 				title: `Disable ${errorLabel} in the entire workspace`,
-				arguments: [diagnostic, textDocumentUri]
+				arguments: [textDocumentUri, diagnostic]
 			},
 			diagnostics: [diagnostic],
 			isPreferred: false

--- a/server/src/codeActions.ts
+++ b/server/src/codeActions.ts
@@ -1,3 +1,4 @@
+/* eslint-disable eqeqeq */
 import {
 	CodeAction,
 	CodeActionParams,
@@ -44,7 +45,9 @@ export function provideQuickFixCodeActions(textDocument: TextDocument, codeActio
 		const ignoreActions = createIgnoreActions(diagnostic, textDocument.uri);
 		quickFixCodeActions.push(...ignoreActions);
 		const viewDocAction = createViewDocAction(diagnostic, textDocument.uri);
-		quickFixCodeActions.push(viewDocAction);
+		if (viewDocAction) {
+			quickFixCodeActions.push(viewDocAction);
+		}
 	}
 	debug(`Provided ${quickFixCodeActions.length} codeActions for ${textDocument.uri}`);
 	return quickFixCodeActions;
@@ -87,6 +90,11 @@ function createQuickFixCodeActions(diagnostic: Diagnostic, quickFix: any, textDo
 }
 
 function createIgnoreActions(diagnostic: Diagnostic, textDocumentUri: string): CodeAction[] {
+	// Sometimes it comes there whereas it shouldn't ... let's avoid a crash
+	if (diagnostic == null) {
+		console.warn('Warning: we should not be in createIgnoreActions as there is no diagnostic set');
+		return [];
+	}
 	const ignoreActions: CodeAction[] = [];
 	let errorLabel = (diagnostic.code as string).split('-')[0].replace(/([A-Z])/g, ' $1').trim();
 
@@ -142,7 +150,12 @@ function createIgnoreActions(diagnostic: Diagnostic, textDocumentUri: string): C
 }
 
 // Create action to view documentation
-function createViewDocAction(diagnostic: Diagnostic, textDocumentUri: string): CodeAction {
+function createViewDocAction(diagnostic: Diagnostic, textDocumentUri: string): CodeAction | null {
+	// Sometimes it comes there whereas it shouldn't ... let's avoid a crash
+	if (diagnostic == null) {
+		console.warn('Warning: we should not be in createViewDocAction as there is no diagnostic set');
+		return null;
+	}
 	const ruleCode = (diagnostic.code as string).split('-')[0];
 	let errorLabel = ruleCode.replace(/([A-Z])/g, ' $1').trim();
 	const viewCodeAction: CodeAction = {
@@ -161,12 +174,19 @@ function createViewDocAction(diagnostic: Diagnostic, textDocumentUri: string): C
 
 // Apply quick fixes
 export async function applyQuickFixes(diagnostics: Diagnostic[], textDocumentUri: string, docManager: DocumentsManager) {
+	// Sometimes it comes there whereas it shouldn't ... let's avoid a crash
+	if (diagnostics == null || diagnostics.length === 0) {
+		console.warn('Warning: we should not be in applyQuickFixes as there is no diagnostics set');
+		return;
+	}
+
 	const textDocument: TextDocument = docManager.getDocumentFromUri(textDocumentUri);
 	const errorIds: number[] = [];
 	for (const diagnostic of diagnostics) {
 		errorIds.push(parseInt((diagnostic.code as string).split('-')[1], 10));
 	}
 	debug(`Request apply QuickFixes for ${textDocumentUri}: ${errorIds.join(',')}`);
+
 	// Call NpmGroovyLint instance fixer
 	const docLinter = docManager.getDocLinter(textDocument.uri);
 	debug(`Start fixing ${textDocument.uri}`);
@@ -198,6 +218,12 @@ export async function applyQuickFixes(diagnostics: Diagnostic[], textDocumentUri
 
 // Quick fix in the whole file
 export async function applyQuickFixesInFile(diagnostics: Diagnostic[], textDocumentUri: string, docManager: DocumentsManager) {
+	// Sometimes it comes there whereas it shouldn't ... let's avoid a crash
+	if (diagnostics == null || diagnostics.length === 0) {
+		console.warn('Warning: we should not be in applyQuickFixesInFile as there is no diagnostics set');
+		return;
+	}
+
 	const textDocument: TextDocument = docManager.getDocumentFromUri(textDocumentUri);
 	const fixRule = (diagnostics[0].code as string).split('-')[0];
 	debug(`Request apply QuickFixes in file for ${fixRule} error in ${textDocumentUri}`);
@@ -210,6 +236,12 @@ export async function applyQuickFixesInFile(diagnostics: Diagnostic[], textDocum
 
 // Add suppress warning
 export async function addSuppressWarning(diagnostic: Diagnostic, textDocumentUri: string, scope: string, docManager: DocumentsManager) {
+	// Sometimes it comes there whereas it shouldn't ... let's avoid a crash
+	if (diagnostic == null) {
+		console.warn('Warning: we should not be in addSuppressWarning as there is no diagnostic set');
+		return;
+	}
+
 	const textDocument: TextDocument = docManager.getDocumentFromUri(textDocumentUri);
 	const allLines = docManager.getTextDocumentLines(textDocument);
 	// Get line to check or create
@@ -246,6 +278,11 @@ export async function addSuppressWarning(diagnostic: Diagnostic, textDocumentUri
 // Add suppress warning
 export async function alwaysIgnoreError(diagnostic: Diagnostic, textDocumentUri: string, docManager: DocumentsManager) {
 	debug(`Request ignore error in all workspace from ${textDocumentUri}`);
+	// Sometimes it comes there whereas it shouldn't ... let's avoid a crash
+	if (diagnostic == null) {
+		console.warn('Warning: we should not be in alwaysIgnoreError as there is no diagnostic set');
+		return [];
+	}
 	const textDocument: TextDocument = docManager.getDocumentFromUri(textDocumentUri);
 	// Get line to check or create
 	const errorCode: string = (diagnostic.code as string).split('-')[0];

--- a/server/src/folder.ts
+++ b/server/src/folder.ts
@@ -3,36 +3,73 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
 import * as fse from "fs-extra";
 import * as path from "path";
+import { ShowMessageRequestParams, MessageType } from 'vscode-languageserver';
 
 const debug = require("debug")("vscode-groovy-lint");
 const glob = require("glob-promise");
 
-// Lint all applicable files of a folder
+const timeToDisplayWaitingMessageMs = 5000;
+
 export async function lintFolder(folders: Array<any>, docManager: DocumentsManager) {
-	const folderList = folders.map(fldr => fldr.fsPath);
-	debug(`Start linting folder(s): ${folderList.join(',')}`);
-	// Browse each folder
-	for (const folder of folderList) {
-		// List applicable files of folder
-		const pathFilesPatternGroovy = path.join(folder, '/**/*.groovy');
-		const pathFilesPatternJenkins = path.join(folder, '/**/Jenkins*');
-		const files = [];
-		for (const pathFilesPattern of [pathFilesPatternGroovy, pathFilesPatternJenkins]) {
-			const pathFiles = await glob(pathFilesPattern);
-			files.push(...pathFiles);
-		}
-		// Trigger a lint for each of the found documents
-		for (const file of files) {
-			const docUri = URI.file(file).toString();
-			let textDocument: TextDocument = docManager.getDocumentFromUri(docUri);
-			// eslint-disable-next-line eqeqeq
-			if (textDocument == null) {
-				const content = await fse.readFile(file, "utf8");
-				textDocument = TextDocument.create(docUri, 'groovy', 1, content.toString());
+
+	let isLinting = true;
+	let continueLinting = true;
+
+	// Function to lint all applicable files of a folder
+	async function processLintFolder() {
+		const folderList = folders.map(fldr => fldr.fsPath);
+		debug(`Start linting folder(s): ${folderList.join(',')}`);
+		// Browse each folder
+		for (const folder of folderList) {
+			// List applicable files of folder
+			const pathFilesPatternGroovy = path.join(folder, '/**/*.groovy');
+			const pathFilesPatternJenkins = path.join(folder, '/**/Jenkins*');
+			const files = [];
+			for (const pathFilesPattern of [pathFilesPatternGroovy, pathFilesPatternJenkins]) {
+				const pathFiles = await glob(pathFilesPattern);
+				files.push(...pathFiles);
 			}
-			// Lint one doc after another , to do not busy too much the processor
-			await docManager.validateTextDocument(textDocument, { showDocumentIfErrors: true });
+			// Trigger a lint for each of the found documents
+			for (const file of files) {
+				const docUri = URI.file(file).toString();
+				let textDocument: TextDocument = docManager.getDocumentFromUri(docUri);
+				// eslint-disable-next-line eqeqeq
+				if (textDocument == null) {
+					const content = await fse.readFile(file, "utf8");
+					textDocument = TextDocument.create(docUri, 'groovy', 1, content.toString());
+				}
+				// Lint one doc after another , to do not busy too much the processor
+				if (continueLinting === true) {
+					await docManager.validateTextDocument(textDocument, { showDocumentIfErrors: true });
+				}
+			}
 		}
+		debug(`Completed linting folder(s): ${folderList.join(',')}`);
+		isLinting = false;
 	}
-	debug(`Completed linting folder(s): ${folderList.join(',')}`);
+
+	// Request lint folders
+	const lintFoldersPromise = processLintFolder();
+
+	// Wait some seconds: if the lint is still processing, display an info message
+	setTimeout(async () => {
+		if (isLinting === true) {
+			const msg: ShowMessageRequestParams = {
+				type: MessageType.Info,
+				message: `'Linting all files of a folder can be long, please be patient :)'`,
+				actions: [
+					{ title: "Ok, keep going" },
+					{ title: "Cancel lint of folders" }
+				]
+			};
+			const req = await docManager.connection.sendRequest('window/showMessageRequest', msg);
+			if (req.title === "Cancel lint of folders") {
+				continueLinting = false;
+			}
+		}
+	}, timeToDisplayWaitingMessageMs);
+
+	// Await folders are linted
+	await lintFoldersPromise;
 }
+

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -14,7 +14,6 @@ import {
     TextDocumentChangeEvent
 } from 'vscode-languageserver';
 import { TextDocument, TextEdit } from 'vscode-languageserver-textdocument';
-const { performance } = require("perf_hooks");
 import { provideQuickFixCodeActions } from './codeActions';
 
 import { DocumentsManager } from './DocumentsManager';
@@ -29,8 +28,6 @@ let connection = createConnection(ProposedFeatures.all);
 
 // Doc manager is a live instance managing the extension all along its execution
 const docManager = new DocumentsManager(connection);
-
-const delayBeforeLintAgainAfterConfigUpdate = 5000;
 
 // Return language server capabilities
 connection.onInitialize((params: InitializeParams) => {
@@ -160,9 +157,9 @@ docManager.documents.onDidSave(async event => {
 // Only keep settings for open documents
 docManager.documents.onDidClose(async event => {
     debug(`Close event received for ${event.document.uri}`);
-    await docManager.resetDiagnostics(event.document.uri);
+    docManager.resetDiagnostics(event.document.uri);
     docManager.removeDocumentSettings(event.document.uri);
-    await docManager.cancelDocumentValidation(event.document.uri);
+    docManager.cancelDocumentValidation(event.document.uri);
 });
 
 


### PR DESCRIPTION
- Fix error [#18 _(codeAction failed with message: Cannot read property 'split' of undefined)_](https://github.com/nvuillam/vscode-groovy-lint/issues/18)
- Add more automated tests for CodeActions
- Display a waiting info message when a Lint Folder request takes more than 5 seconds + allow to cancel the current operation
- Fix perf issue when closing all visible text editors
- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.1.0
  - Upgrade to [Groovy 3.0.3](https://dl.bintray.com/groovy/maven/apache-groovy-binary-3.0.3.zip)