### PR TITLE
Fix #18 - error when diagnostics from other extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.8.2] 2020-04-13 
+
+- New fix of [#18 _(codeAction failed with message: Cannot read property 'split' of undefined)_](https://github.com/nvuillam/vscode-groovy-lint/issues/18): error when diagnostics provided by another VsCode extension
+
 ## [0.8.1] 2020-04-13
 
 - Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.2.0

--- a/server/src/codeActions.ts
+++ b/server/src/codeActions.ts
@@ -28,11 +28,16 @@ const debug = require("debug")("vscode-groovy-lint");
  */
 export function provideQuickFixCodeActions(textDocument: TextDocument, codeActionParams: CodeActionParams, docQuickFixes: any): CodeAction[] {
 	const diagnostics = codeActionParams.context.diagnostics;
-	if (isNullOrUndefined(diagnostics) || diagnostics.length === 0) {
-		return [];
-	}
 	const quickFixCodeActions: CodeAction[] = [];
+	if (isNullOrUndefined(diagnostics) || diagnostics.length === 0) {
+		return quickFixCodeActions;
+	}
+	// Browse diagnostics to get related CodeActions
 	for (const diagnostic of codeActionParams.context.diagnostics) {
+		// Skip Diagnostics not from VsCodeGroovyLint
+		if (diagnostic.source !== 'GroovyLint') {
+			continue;
+		}
 		// Get corresponding QuickFix if existing and convert it as QuickAction
 		const diagCode: string = diagnostic.code + '';
 		if (docQuickFixes && docQuickFixes[diagCode]) {


### PR DESCRIPTION
- New fix of [#18 _(codeAction failed with message: Cannot read property 'split' of undefined)_](https://github.com/nvuillam/vscode-groovy-lint/issues/18): error when diagnostics provided by another VsCode extension