### PR TITLE
QuickFix crash , disable comment errors (see detail)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### [0.9.3] 2020-04-22
+
+- Fixes 
+  - Crash when apply QuickFix after disabling an error with a comment
+  - Error when groovylint-disable and groovylint-disable-next-line are both at the beginning of the source file
+  - Decrease delay before onType lint from 4 seconds to 3 seconds
+  - Misspellings
+
 ### [0.9.2] 2020-04-21
 
 - Hotfix crazy status bar item ([#26](https://github.com/nvuillam/vscode-groovy-lint/pull/26))

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -134,7 +134,7 @@ export function deactivate(): Thenable<void> {
 // Update status list
 async function updateStatus(status: StatusParams): Promise<any> {
 	const incomingStatusDocUri = getStatusParamUri(status);
-	// Start linting / formatting / fixing
+	// Start analyzing / formatting / fixing
 	if (status.state.startsWith('lint.start')) {
 		// Remove doublons on same document
 		statusList = statusList.filter(statusObj => incomingStatusDocUri !== getStatusParamUri(statusObj));
@@ -219,9 +219,9 @@ async function refreshStatusBar(): Promise<any> {
 	// Compute and display job statuses
 	const tooltips = statusList.map((status) => {
 		return (status.state === 'lint.start') ? '• analyzing ' + status.lastFileName + ' ...' :
-			(status.state === 'lint.start.fix') ? '• fixing ' + status.lastFileName + ' ...' :
+			(status.state === 'lint.start.fix') ? '• auto-fixing ' + status.lastFileName + ' ...' :
 				(status.state === 'lint.start.format') ? '• formatting ' + status.lastFileName + ' ...' :
-					(status.state === 'lint.error') ? 'Error while processing ' + status.lastFileName :
+					(status.state === 'lint.error') ? '• Error while processing ' + status.lastFileName :
 						`ERROR in GroovyLint: unknown status ${status.state} (plz contact developers if you see that`;
 	});
 	if (tooltips.length > 0) {

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -37,7 +37,7 @@ const numberOfGroovyLintCommands = 9;
 //const numberOfDiagnosticsForBigGroovyLintFix = 683;
 
 const numberOfDiagnosticsForTinyGroovyLint = 39;
-const numberOfDiagnosticsForTinyGroovyLintFix = 20;
+const numberOfDiagnosticsForTinyGroovyLintFix = 12;
 
 const numberOfDiagnosticsForJenkinsfileLint = 203;
 const numberOfDiagnosticsForJenkinsfileLintFix = 202;
@@ -117,28 +117,37 @@ suite('VsCode GroovyLint Test Suite', async () => {
 	test("3.0.0.1 Disable next line", async () => {
 		console.log("3.0.0.1  Disable next line");
 		const lineNb = 7;
-
+		const docDiagnostics = vscode.languages.getDiagnostics(testDocs['tinyGroovy'].doc.uri);
 		await disableRule('groovyLint.disableRule', testDocs['tinyGroovy'].doc.uri, 'Indentation', lineNb);
+		await waitUntil(() => diagnosticsChanged(testDocs['tinyGroovy'].doc.uri, docDiagnostics), 30000);
+
+		const docDiagnostics2 = vscode.languages.getDiagnostics(testDocs['tinyGroovy'].doc.uri);
 		await disableRule('groovyLint.disableRule', testDocs['tinyGroovy'].doc.uri, 'UnnecessarySemicolon', lineNb + 1);
+		await waitUntil(() => diagnosticsChanged(testDocs['tinyGroovy'].doc.uri, docDiagnostics2), 30000);
 
 		const newSource = getActiveEditorText();
 		const allLines = newSource.replace(/\r?\n/g, "\r\n").split("\r\n");
 		assert(allLines[lineNb - 1].includes(`/* groovylint-disable-next-line Indentation, UnnecessarySemicolon */`), 'groovylint-disable-next-line not added correctly: ' + allLines[lineNb - 1]);
 
-	}).timeout(30000);
+	}).timeout(60000);
 
 	// Disable rules for entire file
 	test("3.0.0.2 Disable rules in all file", async () => {
 		console.log("3.0.0.2 Disable rules in all file");
 
+		const docDiagnostics = vscode.languages.getDiagnostics(testDocs['tinyGroovy'].doc.uri);
 		await disableRule('groovyLint.disableRuleInFile', testDocs['tinyGroovy'].doc.uri, 'CompileStatic', null);
+		await waitUntil(() => diagnosticsChanged(testDocs['tinyGroovy'].doc.uri, docDiagnostics), 30000);
+
+		const docDiagnostics2 = vscode.languages.getDiagnostics(testDocs['tinyGroovy'].doc.uri);
 		await disableRule('groovyLint.disableRuleInFile', testDocs['tinyGroovy'].doc.uri, 'DuplicateStringLiteral', null);
+		await waitUntil(() => diagnosticsChanged(testDocs['tinyGroovy'].doc.uri, docDiagnostics2), 30000);
 
 		const newSource = getActiveEditorText();
 		const allLines = newSource.replace(/\r?\n/g, "\r\n").split("\r\n");
 		assert(allLines[0].includes('/* groovylint-disable CompileStatic, DuplicateStringLiteral */'), 'groovylint-disable not added correctly : ' + allLines[0]);
 
-	}).timeout(30000);
+	}).timeout(60000);
 
 	// Quick fix error
 	test("3.0.1 Quick fix error in tiny document", async () => {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
 			},
 			{
 				"command": "groovyLint.lintFolder",
-				"title": "Lint Groovy file in this folder"
+				"title": "Analyze groovy files in this folder"
 			}
 		],
 		"menus": {

--- a/server/src/DocumentsManager.ts
+++ b/server/src/DocumentsManager.ts
@@ -386,7 +386,7 @@ export class DocumentsManager {
 					start: { line: 0, character: 0 },
 					end: { line: 0, character: 0 }
 				},
-				message: `GroovyLint is ${optns.verb}...`,
+				message: `GroovyLint is ${optns.verb} code...`,
 				source: 'GroovyLint'
 			};
 			await this.connection.sendDiagnostics({ uri: docUri, diagnostics: [waitingDiagnostic] });

--- a/server/src/codeActions.ts
+++ b/server/src/codeActions.ts
@@ -285,14 +285,17 @@ export async function disableErrorWithComment(diagnostic: Diagnostic, textDocume
 		commentRules.sort();
 		const disableLine = indent + `/* ${disableKey} ${[...new Set(commentRules)].join(", ")} */`;
 		await applyTextDocumentEditOnWorkspace(docManager, textDocument, disableLine, { replaceLinePos: prevLinePos });
-		docManager.removeDiagnostics([diagnostic], textDocument.uri, disableKey === 'groovylint-disable');
+		// Removed as validateTextDocument is called after. Worse performances but safer. 
+		// docManager.removeDiagnostics([diagnostic], textDocument.uri, disableKey === 'groovylint-disable');
 	}
 	else {
 		// Add new /* groovylint-disable */ or /* groovylint-disable-next-line */
 		const disableLine = indent + `/* ${disableKey} ${errorCode} */`;
 		await applyTextDocumentEditOnWorkspace(docManager, textDocument, disableLine, { insertLinePos: linePos });
-		docManager.removeDiagnostics([diagnostic], textDocument.uri, disableKey === 'groovylint-disable', linePos);
+		// Removed as validateTextDocument is called after. Worse performances but safer. 
+		// docManager.removeDiagnostics([diagnostic], textDocument.uri, disableKey === 'groovylint-disable', linePos);
 	}
+	docManager.validateTextDocument(textDocument, { force: true });
 }
 
 /* Depending of context, diagnostic.range can be 
@@ -311,7 +314,8 @@ function getDiagnosticRangeInfo(range: any, startOrEnd: string): any {
 
 // Parse groovylint comment 
 function parseGroovyLintComment(type: string, line: string) {
-	if (line.includes(type)) {
+	if (line.includes(type) &&
+		!(type === 'groovylint-disable' && line.includes('groovylint-disable-next-line'))) {
 		const typeDetail = line
 			.replace("/*", "")
 			.replace("//", "")

--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -9,7 +9,7 @@ export const COMMAND_DISABLE_ERROR_FOR_LINE = Command.create('Disable rule for t
 export const COMMAND_DISABLE_ERROR_FOR_FILE = Command.create('Disable rule for this entire file', 'groovyLint.disableRuleInFile');
 export const COMMAND_DISABLE_ERROR_FOR_PROJECT = Command.create('Disable rule for this entire project', 'groovyLint.disableRuleInProject');
 export const COMMAND_SHOW_RULE_DOCUMENTATION = Command.create('Show documentation for rule', 'groovyLint.showDocumentationForRule');
-export const COMMAND_LINT_FOLDER = Command.create('Lint Groovy file in this folder', 'groovyLint.lintFolder');
+export const COMMAND_LINT_FOLDER = Command.create('Analyze groovy files in this folder', 'groovyLint.lintFolder');
 
 export const commands = [
 	COMMAND_LINT,

--- a/server/src/folder.ts
+++ b/server/src/folder.ts
@@ -18,7 +18,7 @@ export async function lintFolder(folders: Array<any>, docManager: DocumentsManag
 	// Function to lint all applicable files of a folder
 	async function processLintFolder() {
 		const folderList = folders.map(fldr => fldr.fsPath);
-		debug(`Start linting folder(s): ${folderList.join(',')}`);
+		debug(`Start analyzing folder(s): ${folderList.join(',')}`);
 		// Browse each folder
 		for (const folder of folderList) {
 			// List applicable files of folder
@@ -44,7 +44,7 @@ export async function lintFolder(folders: Array<any>, docManager: DocumentsManag
 				}
 			}
 		}
-		debug(`Completed linting folder(s): ${folderList.join(',')}`);
+		debug(`Completed analyzing folder(s): ${folderList.join(',')}`);
 		isLinting = false;
 	}
 
@@ -56,10 +56,10 @@ export async function lintFolder(folders: Array<any>, docManager: DocumentsManag
 		if (isLinting === true) {
 			const msg: ShowMessageRequestParams = {
 				type: MessageType.Info,
-				message: `'Linting all files of a folder can be long, please be patient :)'`,
+				message: `'Analyzing all files of a folder can be long, please be patient :)'`,
 				actions: [
 					{ title: "Ok, keep going" },
-					{ title: "Cancel lint of folders" }
+					{ title: "Cancel analysis of folder files" }
 				]
 			};
 			const req = await docManager.connection.sendRequest('window/showMessageRequest', msg);

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -59,7 +59,7 @@ export async function executeLinter(textDocument: TextDocument, docManager: Docu
 
 	// Manage format & fix params
 	let format = false;
-	let verb = 'linting';
+	let verb = 'analyzing';
 	// Add format param if necessary
 	if (opts.format) {
 		format = true;
@@ -123,7 +123,7 @@ export async function executeLinter(textDocument: TextDocument, docManager: Docu
 
 	// If source has not changed, do not lint again
 	if (isSimpleLintIdenticalSource === true) {
-		debug(`Ignoring linting of ${textDocument.uri} as its content has not changed since previous lint`);
+		debug(`Ignoring new analyze of ${textDocument.uri} as its content has not changed since previous lint`);
 		linter = prevLinter;
 	}
 	else {
@@ -149,7 +149,7 @@ export async function executeLinter(textDocument: TextDocument, docManager: Docu
 		} catch (e) {
 			// If error, send notification to client
 			console.error('VsCode Groovy Lint error: ' + e.message + '\n' + e.stack);
-			debug(`Error linting ${textDocument.uri}` + e.message + '\n' + e.stack);
+			debug(`Error processing ${textDocument.uri}` + e.message + '\n' + e.stack);
 			docManager.connection.sendNotification(StatusNotification.type, {
 				id: linterTaskId,
 				state: 'lint.error',

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -23,7 +23,7 @@ import { ActiveDocumentNotification } from './types';
 const debug = require("debug")("vscode-groovy-lint");
 const NpmGroovyLint = require("npm-groovy-lint/jdeploy-bundle/groovy-lint.js");
 
-const onTypeDelayBeforeLint = 4000;
+const onTypeDelayBeforeLint = 3000;
 
 // Create a connection for the server. The connection uses Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
@@ -137,7 +137,11 @@ docManager.documents.onDidOpen(async (event) => {
 // when the text document first opened or when its content has changed.
 let lastCall: string;
 docManager.documents.onDidChangeContent(async (change: TextDocumentChangeEvent<TextDocument>) => {
+    if (change.document.languageId !== 'groovy') {
+        return;
+    }
     docManager.setCurrentDocumentUri(change.document.uri);
+    docManager.deleteDocLinter(change.document.uri);
     const settings = await docManager.getDocumentSettings(change.document.uri);
     const skip = docManager.checkSkipNextOnDidChangeContent(change.document.uri);
     if (settings.lint.trigger === 'onType' && !skip) {


### PR DESCRIPTION
  - Crash when apply QuickFix after disabling an error with a comment
  - Error when groovylint-disable and groovylint-disable-next-line are both at the beginning of the source file
  - Decrease delay before onType lint from 4 seconds to 3 seconds
  - Misspellings