### PR TITLE
Upgrade to npm-groovy-lint v4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Change Log
 
+### [0.10.0] 2020-05-01
+
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.6.0
+  - New fix rules
+    - SpaceBeforeClosingBrace
+    - UnnecessaryDefInMethodDeclaration
+    - UnnecessaryPackageReference
+    - UnnecessaryParenthesesForMethodCallWithClosure
+
+  - Updated fix rules
+    - MisorderedStaticImports: Fix `@Grapes` killer fixing rule
+    - ElseBlockBrace: issue when instruction is on the same line than `else`
+
 ### [0.9.5] 2020-04-29
 
 - Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.5.4

--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ Please follow [Contribution instructions](https://github.com/nvuillam/vscode-gro
 
 ## Release Notes
 
+### [0.10.0] 2020-05-01
+
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.6.0
+  - New fix rules
+    - SpaceBeforeClosingBrace
+    - UnnecessaryDefInMethodDeclaration
+    - UnnecessaryPackageReference
+    - UnnecessaryParenthesesForMethodCallWithClosure
+
+  - Updated fix rules
+    - MisorderedStaticImports: Fix `@Grapes` killer fixing rule
+    - ElseBlockBrace: issue when instruction is on the same line than `else`
+
 ### [0.9.4] 2020-04-28
 
 - Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.5.0 [Davide Bizzarri](https://github.com/b1zzu)
@@ -113,51 +126,6 @@ Please follow [Contribution instructions](https://github.com/nvuillam/vscode-gro
   - [Disable rules using comments in source](https://github.com/nvuillam/npm-groovy-lint#disabling-rules-in-source) using [eslint style](https://eslint.org/docs/user-guide/configuring#disabling-rules-with-inline-comments)
   - Cancel a CodeNarc Lint when a similar CodeNarcServer request is received (allowing onType mode for language servers)
   
-### [0.8.1] 2020-04-13
-
-- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.2.0
-  - Display **source parsing errors**
-  - New fix rules (thanks [CatSue](https://github.com/CatSue) !):
-    - SpaceAfterSemicolon
-    - SpaceAfterWhile
-- Remove useless files from VsCode extension package
-
-### [0.7.2] 2020-04-12
-
-- Fix error [#18 _(codeAction failed with message: Cannot read property 'split' of undefined)_](https://github.com/nvuillam/vscode-groovy-lint/issues/18)
-- Add more automated tests for CodeActions
-- Display a waiting info message when a Lint Folder request takes more than 5 seconds + allow to cancel the current operation
-- Fix perf issue when closing all visible text editors
-- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.1.0
-  - Upgrade to [Groovy 3.0.3](https://dl.bintray.com/groovy/maven/apache-groovy-binary-3.0.3.zip)
-
-### [0.7.1] 2020-04-09
-
-- Add setting **groovyLint.debug.enable** : Display more logs in VsCode Output panel (select "GroovyLint") for issue investigation
-- Update settings definition in README documentation
-
-### [0.7.0] 2020-04-08
-
-- New command **Lint Groovy in folder** available in folder context menu
-- Performances: avoid to lint again a file if it has already been linter with the same content
-- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.0.0
-  - **Much better performances on Linux and MacOs**
-  - When formatting, always run some custom npm-groovy-lint fix rules not corresponding to CodeNarc violations
-  - Return CodeNarc and Groovy versions when --version options is called
-  - Fixes
-    - Lost indentation when applying some fix rules
-  - Updated fix rules:
-    - IndentationClosingBraces
-    - IndentationComments
-    - SpaceAfterCatch
-    - SpaceAfterIf
-  - New fix rules:
-    - ClassEndsWithBlankLine
-    - ClassStartsWithNewLine
-    - SpaceAfterFor
-    - SpaceAfterSwitch
-- Add Jenkinsfile in test files
-
 ### PREVIOUS VERSIONS
 
 See complete [CHANGELOG](https://github.com/nvuillam/vscode-groovy-lint/blob/master/CHANGELOG.md)

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -37,7 +37,7 @@ const numberOfGroovyLintCommands = 9;
 //const numberOfDiagnosticsForBigGroovyLintFix = 683;
 
 const numberOfDiagnosticsForTinyGroovyLint = 39;
-const numberOfDiagnosticsForTinyGroovyLintFix = 12;
+const numberOfDiagnosticsForTinyGroovyLintFix = 10;
 
 const numberOfDiagnosticsForJenkinsfileLint = 203;
 const numberOfDiagnosticsForJenkinsfileLintFix = 202;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -498,9 +498,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "npm-groovy-lint": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-4.5.4.tgz",
-      "integrity": "sha512-n9xTPB/evzRduBnvzNsNWIMFBSCFz3JyV7yN6Su3yICVNz7iRrXtE4tKQWWrHaGKJt0fxgU1M+Cy7M4qv7iEeg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-4.6.0.tgz",
+      "integrity": "sha512-/6QLip5i2g44r2tjkYZU/4HxlFrubr/6l6OkTDSIP/oUhUymbSpwFWos6+LvhLZGIgWxswhixYbmgIpex/Eimg==",
       "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",
-    "npm-groovy-lint": "^4.5.4",
+    "npm-groovy-lint": "^4.6.0",
     "vscode-languageserver-textdocument": "^1.0.1"
   }
 }


### PR DESCRIPTION
- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.6.0
  - New fix rules
    - SpaceBeforeClosingBrace
    - UnnecessaryDefInMethodDeclaration
    - UnnecessaryPackageReference
    - UnnecessaryParenthesesForMethodCallWithClosure

  - Updated fix rules
    - MisorderedStaticImports: Fix `@Grapes` killer fixing rule
    - ElseBlockBrace: issue when instruction is on the same line than `else`