### PR TITLE
Upgrade to npm-groovy-lint 4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Change Log
 
+### [0.11.0] 2020-05-06
+
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.7.0
+  - New fix rules
+    - BracesForClass
+    - BracesForForLoop
+    - BracesForIfElse
+    - BracesForMethod
+    - BracesForTryCatchFinally
+    - ExplicitArrayListInstantiation
+    - MissingBlankLineAfterImports
+    - MissingBlankLineAfterPackage
+
+  - Updated fix rules
+    - UnnecessaryGString: Fix replacements containing `\n` and `\r`
+
 ### [0.10.0] 2020-05-01
 
 - Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.6.0

--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ Please follow [Contribution instructions](https://github.com/nvuillam/vscode-gro
 
 ## Release Notes
 
+### [0.11.0] 2020-05-06
+
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.7.0
+  - New fix rules
+    - BracesForClass
+    - BracesForForLoop
+    - BracesForIfElse
+    - BracesForMethod
+    - BracesForTryCatchFinally
+    - ExplicitArrayListInstantiation
+    - MissingBlankLineAfterImports
+    - MissingBlankLineAfterPackage
+
+  - Updated fix rules
+    - UnnecessaryGString: Fix replacements containing `\n` and `\r`
+
 ### [0.10.0] 2020-05-01
 
 - Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.6.0

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -40,7 +40,7 @@ const numberOfDiagnosticsForTinyGroovyLint = 39;
 const numberOfDiagnosticsForTinyGroovyLintFix = 10;
 
 const numberOfDiagnosticsForJenkinsfileLint = 203;
-const numberOfDiagnosticsForJenkinsfileLintFix = 202;
+const numberOfDiagnosticsForJenkinsfileLintFix = 200;
 
 suite('VsCode GroovyLint Test Suite', async () => {
 	vscode.window.showInformationMessage('Start all VsCode Groovy Lint tests');

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -133,9 +133,9 @@
       "dev": true
     },
     "cli-progress": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.8.1.tgz",
-      "integrity": "sha512-tzIOjWPHnXWCS6MNFOVE78mXtzBf/Z4//mfwi33eQ72cifLwXq3hsOGAukocf1Fygp7Zhylept1sUpN43qQEbg==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.8.2.tgz",
+      "integrity": "sha512-qRwBxLldMSfxB+YGFgNRaj5vyyHe1yMpVeDL79c+7puGujdKJHQHydgqXDcrkvQgJ5U/d3lpf6vffSoVVUftVQ==",
       "dev": true,
       "requires": {
         "colors": "^1.1.2",
@@ -498,9 +498,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "npm-groovy-lint": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-4.6.0.tgz",
-      "integrity": "sha512-/6QLip5i2g44r2tjkYZU/4HxlFrubr/6l6OkTDSIP/oUhUymbSpwFWos6+LvhLZGIgWxswhixYbmgIpex/Eimg==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-4.7.0.tgz",
+      "integrity": "sha512-wSKUIjrg+cdirMAAJ58swjjR2HnrQrVnUR8kgdOPzdB/njQpA7tNzCyHPiJxt8js577gQoWb/ZgqiYEHxG2NJQ==",
       "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",
-    "npm-groovy-lint": "^4.6.0",
+    "npm-groovy-lint": "^4.7.0",
     "vscode-languageserver-textdocument": "^1.0.1"
   }
 }


### PR DESCRIPTION
- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.7.0
  - New fix rules
    - BracesForClass
    - BracesForForLoop
    - BracesForIfElse
    - BracesForMethod
    - BracesForTryCatchFinally
    - ExplicitArrayListInstantiation
    - MissingBlankLineAfterImports
    - MissingBlankLineAfterPackage

  - Updated fix rules
    - UnnecessaryGString: Fix replacements containing `\n` and `\r`