### PR TITLE
Upgrade to npm-groovy-lint 4.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.13.1] 2020-05-12
+
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.11.0
+  - Technical fixes
+
 ## [0.13.0] 2020-05-12
 
 - New setting `groovyLint.insight.enable`: Allow to send anonymous usage statistics used only to improve the tool (we will of course never send your code or sensitive information)

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -672,9 +672,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "npm-groovy-lint": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-4.10.2.tgz",
-      "integrity": "sha512-fLGPVikzktf/Js/TVTqT0fbm4a621IXn6dIM6nqd+Tw7larJvXPVCtrl8eaAg8iAK00kyOh4KFKzVOrUMLyzpA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-4.11.0.tgz",
+      "integrity": "sha512-H9GnHvUBW4tr6HxF7affaKg3+OfFRiBVNFn8f1IgcAvm0dNmY8eWgfUi3UUf0X4zacesszYSwIMTay0CEDgcLg==",
       "dev": true,
       "requires": {
         "@analytics/segment": "^0.4.0",

--- a/server/package.json
+++ b/server/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",
-    "npm-groovy-lint": "^4.10.2",
+    "npm-groovy-lint": "^4.11.0",
     "vscode-languageserver-textdocument": "^1.0.1"
   }
 }


### PR DESCRIPTION
- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.11.0
  - Technical fixes