### PR TITLE
Use Indent size provided by VsCode Formatter API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.15.0] 2020-05-18
+
+- Use Indent size provided by VsCode Formatter API [#34](https://github.com/nvuillam/vscode-groovy-lint/issues/34)
+- Add Formatter in Vs Code extension categories [#41](https://github.com/nvuillam/vscode-groovy-lint/issues/41)
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.13.0
+  - Manage to send options for rules sent in `rulesets`: Ex: `Indentation{"spacesPerIndentLevel":2,"severity":"warning"},UnnecessarySemicolon`
+
 ## [0.14.0] 2020-05-18
 
 - Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.12.0

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Please follow [Contribution instructions](https://github.com/nvuillam/vscode-gro
 
 ## Release Notes
 
+### [0.15.0] 2020-05-18
+
+- Use Indent size provided by VsCode Formatter API [#34](https://github.com/nvuillam/vscode-groovy-lint/issues/34)
+- Add Formatter in Vs Code extension categories [#41](https://github.com/nvuillam/vscode-groovy-lint/issues/41)
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.13.0
+
 ### [0.14.0] 2020-05-18
 
 - Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.12.0

--- a/client/src/test/examples/tinyGroovy.groovy
+++ b/client/src/test/examples/tinyGroovy.groovy
@@ -3,7 +3,7 @@ import groovy.json.*
 import groovy.time.TimeCategory
 import static groovyx.gpars.GParsPool.withPool
 
-        def script = new GroovyScriptEngine( '.' ).with{
+        def script = new GroovyScriptEngine( "." ).with{
                 loadScriptByName( 'Utils.groovy' ) ;
    }
 this.metaClass.mixin script

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -36,7 +36,7 @@ const numberOfGroovyLintCommands = 9;
 //const numberOfDiagnosticsForBigGroovyLint = 4361;
 //const numberOfDiagnosticsForBigGroovyLintFix = 683;
 
-const numberOfDiagnosticsForTinyGroovyLint = 39;
+const numberOfDiagnosticsForTinyGroovyLint = 32;
 const numberOfDiagnosticsForTinyGroovyLintFix = 9;
 
 const numberOfDiagnosticsForJenkinsfileLint = 203;
@@ -116,18 +116,18 @@ suite('VsCode GroovyLint Test Suite', async () => {
 	// Disable rules for a line
 	test("3.0.0.1 Disable next line", async () => {
 		console.log("3.0.0.1  Disable next line");
-		const lineNb = 7;
+		const lineNb = 6;
 		const docDiagnostics = vscode.languages.getDiagnostics(testDocs['tinyGroovy'].doc.uri);
-		await disableRule('groovyLint.disableRule', testDocs['tinyGroovy'].doc.uri, 'Indentation', lineNb);
+		await disableRule('groovyLint.disableRule', testDocs['tinyGroovy'].doc.uri, 'SpaceBeforeOpeningBrace', lineNb);
 		await waitUntil(() => diagnosticsChanged(testDocs['tinyGroovy'].doc.uri, docDiagnostics), 30000);
 
 		const docDiagnostics2 = vscode.languages.getDiagnostics(testDocs['tinyGroovy'].doc.uri);
-		await disableRule('groovyLint.disableRule', testDocs['tinyGroovy'].doc.uri, 'UnnecessarySemicolon', lineNb + 1);
+		await disableRule('groovyLint.disableRule', testDocs['tinyGroovy'].doc.uri, 'UnnecessaryGString', lineNb + 1);
 		await waitUntil(() => diagnosticsChanged(testDocs['tinyGroovy'].doc.uri, docDiagnostics2), 30000);
 
 		const newSource = getActiveEditorText();
 		const allLines = newSource.replace(/\r?\n/g, "\r\n").split("\r\n");
-		assert(allLines[lineNb - 1].includes(`/* groovylint-disable-next-line Indentation, UnnecessarySemicolon */`), 'groovylint-disable-next-line not added correctly: ' + allLines[lineNb - 1]);
+		assert(allLines[lineNb - 1].includes(`/* groovylint-disable-next-line SpaceBeforeOpeningBrace, UnnecessaryGString */`), 'groovylint-disable-next-line not added correctly: ' + allLines[lineNb - 1]);
 
 	}).timeout(60000);
 
@@ -154,7 +154,7 @@ suite('VsCode GroovyLint Test Suite', async () => {
 		console.log("Start 3.0.1 Quick fix an error in tiny document");
 		const textBefore = getActiveEditorText();
 		const docDiagnostics = vscode.languages.getDiagnostics(testDocs['tinyGroovy'].doc.uri);
-		const diagnostic = docDiagnostics.filter(diag => (diag.code as string).startsWith('Indentation'))[0];
+		const diagnostic = docDiagnostics.filter(diag => (diag.code as string).startsWith('UnnecessarySemicolon'))[0];
 		// Request code actions
 		const codeActions = await executeCommand('vscode.executeCodeActionProvider', [
 			testDocs['tinyGroovy'].doc.uri,
@@ -177,7 +177,7 @@ suite('VsCode GroovyLint Test Suite', async () => {
 		console.log("Start 3.0.2 Quick fix and error type in tiny document");
 		const textBefore = getActiveEditorText();
 		const docDiagnostics = vscode.languages.getDiagnostics(testDocs['tinyGroovy'].doc.uri);
-		const diagnostic = docDiagnostics.filter(diag => (diag.code as string).startsWith('Indentation'))[0];
+		const diagnostic = docDiagnostics.filter(diag => (diag.code as string).startsWith('UnnecessarySemicolon'))[0];
 		// Request code actions
 		const codeActions = await executeCommand('vscode.executeCodeActionProvider', [
 			testDocs['tinyGroovy'].doc.uri,
@@ -352,8 +352,8 @@ async function disableRule(cmd: string, docUri: vscode.Uri, ruleName: string, li
 	const textBefore = getActiveEditorText();
 	const docDiagnostics = vscode.languages.getDiagnostics(docUri);
 	const diagnostic = docDiagnostics.filter(diag => (diag.code as string).startsWith(ruleName) && (line == null || diag.range.start.line === (line - 1)))[0];
-	console.log('Diagnostic identified: ' + JSON.stringify(diagnostic));
-	assert(diagnostic != null, `Diagnostic not found at line ${line}\n : ${textBefore.split('\r\n')[line]}`);
+	console.log(`Diagnostic ${ruleName} identified: ${JSON.stringify(diagnostic)}`);
+	assert(diagnostic != null, `Diagnostic ${ruleName} not found at line ${line}\n : ${textBefore.split('\r\n')[line]}`);
 	// Request code actions
 	const codeActions = await executeCommand('vscode.executeCodeActionProvider', [
 		docUri,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 	},
 	"categories": [
 		"Programming Languages",
-		"Linters"
+		"Linters",
+		"Formatters"
 	],
 	"repository": {
 		"type": "git",
@@ -214,6 +215,12 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Enables GroovyLint as a formatter."
+				},
+				"groovyLint.format.useDocumentIndentSize": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": true,
+					"description": "Use the indent size provided by VsCode (overrides Indentation.spacesPerIndentLevel property in .groovylintrc.json)"
 				},
 				"groovyLint.basic.loglevel": {
 					"scope": "resource",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -682,9 +682,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "npm-groovy-lint": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-4.12.0.tgz",
-      "integrity": "sha512-058+59b8gAw274sBvVQDK8YHbRh0pK0dTvFbr2lhHB/V5NQraGEVspLcT5aW3yKRYzpNISjULCFEeH6VFS32PQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-4.13.0.tgz",
+      "integrity": "sha512-zRgJLMKtZg4ly1ZTVlZp3fhYcX/gopqIyvG1xeQI2VWD+658kn4g9Pm2xrddT0fDQ9TF4l1iUJwIALaYhPgusA==",
       "dev": true,
       "requires": {
         "@analytics/segment": "^0.4.0",

--- a/server/package.json
+++ b/server/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",
-    "npm-groovy-lint": "^4.12.0",
+    "npm-groovy-lint": "^4.13.0",
     "vscode-languageserver-textdocument": "^1.0.1"
   }
 }

--- a/server/src/DocumentsManager.ts
+++ b/server/src/DocumentsManager.ts
@@ -169,6 +169,13 @@ export class DocumentsManager {
 		return result!;
 	}
 
+	async updateDocumentSettings(resource: string, settingUpdate: VsCodeGroovyLintSettings) {
+		let docSettings = await this.getDocumentSettings(resource);
+		docSettings = Object.assign(docSettings, settingUpdate);
+		this.documentSettings.set(resource, docSettings as unknown as any);
+		return docSettings;
+	}
+
 	// Remove document settings when closed
 	removeDocumentSettings(uri: string) {
 		if (uri === 'all') {

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -123,6 +123,18 @@ export async function executeLinter(textDocument: TextDocument, docManager: Docu
 	}
 	let linter;
 
+	// Add Indent size provided by VsCode API
+	if (settings.tabSize && settings.format.useDocumentIndentSize === true) {
+		npmGroovyLintConfig.rulesets = `Indentation{"spacesPerIndentLevel":${settings.tabSize}}`;
+		npmGroovyLintConfig.rulesetsoverridetype = "appendConfig";
+	}
+	// Disable Indentation rule if Indent size setting is not found
+	else if (settings.format.useDocumentIndentSize === true) {
+		npmGroovyLintConfig.rulesets = `Indentation{"enabled":false}`;
+		npmGroovyLintConfig.rulesetsoverridetype = "appendConfig";
+	}
+
+
 	// If source has not changed, do not lint again
 	if (isSimpleLintIdenticalSource === true) {
 		debug(`Ignoring new analyze of ${textDocument.uri} as its content has not changed since previous lint`);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -93,7 +93,10 @@ connection.onExecuteCommand(async (params: ExecuteCommandParams) => {
 // Handle formatting request from client
 connection.onDocumentFormatting(async (params: DocumentFormattingParams): Promise<TextEdit[]> => {
     const { textDocument } = params;
-    debug(`Formatting request received from client for ${textDocument.uri}`);
+    debug(`Formatting request received from client for ${textDocument.uri} with params ${JSON.stringify(params)}`);
+    if (params && params.options.tabSize) {
+        docManager.updateDocumentSettings(textDocument.uri, { tabSize: params.options.tabSize });
+    }
     const document = docManager.getDocumentFromUri(textDocument.uri);
     const textEdits: TextEdit[] = await docManager.formatTextDocument(document);
     // Lint again the sources

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -39,10 +39,11 @@ export namespace OpenNotification {
 
 // Usable settings
 export interface VsCodeGroovyLintSettings {
-	enable: boolean;
-	lint: any;
-	fix: any;
-	format: any;
-	basic: any;
-	insight: any;
+	enable?: boolean;
+	lint?: any;
+	fix?: any;
+	format?: any;
+	basic?: any;
+	insight?: any;
+	tabSize?: number;
 }


### PR DESCRIPTION
- Use Indent size provided by VsCode Formatter API (Closes #34)

- Add Formatter in Vs Code extension categories (Closes #41) 

- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.13.0
  - Manage to send options for rules sent in `rulesets`: Ex: `Indentation{"spacesPerIndentLevel":2,"severity":"warning"},UnnecessarySemicolon`

