### PR TITLE
Fixes :)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.16.1] 2020-05-27
+
+- Fixes
+  - When a rule is ignored for all project (updating .groovylintrc.json), lint again all open documents [(#46)](https://github.com/nvuillam/vscode-groovy-lint/issues/47)
+  - Setting `groovyLint.fix.trigger` was not updateable [(#47)](https://github.com/nvuillam/vscode-groovy-lint/issues/47)
+  - After applying a QuickFix, wait for the text to be updated to trigger a new code analysis
+  - Better catch and display of fatal errors
+
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v5.0.2
+  - Avoid to apply wrong fix in case of CodeNarc false positive
+  - New fix rules
+    - BlankLineBeforePackage
+  - Updated fix rules
+    - BracesForIfElse
+    - BracesForMethod
+    - BracesForTryCatchFinally
+    - ClassEndsWithBlankLine
+    - ClassStartsWithBlankLine
+    - MissingBlankLineAfterImports
+    - MissingBlankLineAfterPackage
+    - UnnecessaryGroovyImport
+    - UnusedImport
+
 ## [0.16.0] 2020-25-05
 
 - Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v5.0.0

--- a/README.md
+++ b/README.md
@@ -77,7 +77,30 @@ Please follow [Contribution instructions](https://github.com/nvuillam/vscode-gro
 
 ## Release Notes
 
-## [0.16.0] 2020-25-05
+### [0.16.1] 2020-05-27
+
+- Fixes
+  - When a rule is ignored for all project (updating .groovylintrc.json), lint again all open documents [(#46)](https://github.com/nvuillam/vscode-groovy-lint/issues/47)
+  - Setting `groovyLint.fix.trigger` was not updateable [(#47)](https://github.com/nvuillam/vscode-groovy-lint/issues/47)
+  - After applying a QuickFix, wait for the text to be updated to trigger a new code analysis
+  - Better catch and display of fatal errors
+
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v5.0.2
+  - Avoid to apply wrong fix in case of CodeNarc false positive
+  - New fix rules
+    - BlankLineBeforePackage
+  - Updated fix rules
+    - BracesForIfElse
+    - BracesForMethod
+    - BracesForTryCatchFinally
+    - ClassEndsWithBlankLine
+    - ClassStartsWithBlankLine
+    - MissingBlankLineAfterImports
+    - MissingBlankLineAfterPackage
+    - UnnecessaryGroovyImport
+    - UnusedImport
+
+### [0.16.0] 2020-05-25
 
 - Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v5.0.0
   - **BIG BANG**: Improve performances, compatibility, architecture and delivery
@@ -87,7 +110,7 @@ Please follow [Contribution instructions](https://github.com/nvuillam/vscode-gro
     - Get rid of [request](https://github.com/request/request) dependency
       - Use [axios](https://github.com/axios/axios) for promisified http calls
 
-## [0.15.1] 2020-05-22
+### [0.15.1] 2020-05-22
 
 - Troubleshoot Java installation issue
 - Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v4.14.0

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
 				},
 				"groovyLint.fix.trigger": {
 					"scope": "resource",
-					"type": "boolean",
+					"type": "string",
 					"enum": [
 						"onSave",
 						"user"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -466,9 +466,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "npm-groovy-lint": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-5.0.1.tgz",
-      "integrity": "sha512-qFhtJYrgEAVK1ykGQhmAP4PjVdahZNHbsAWRCiaOOTSbriEo5lM3Hcvq8ZNcuMoanwS2Ex5w9wNYVO902z4VlQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-5.0.2.tgz",
+      "integrity": "sha512-WGI+v0gVYceR5hzjBZgUUQrqfnlaELfZx6m8HAAxqIl4TJ/8u9PxWeWiV2IgBtbUPNd42otPoAT8l5rhmv4OcA==",
       "dev": true,
       "requires": {
         "@analytics/segment": "^0.4.0",

--- a/server/package.json
+++ b/server/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",
-    "npm-groovy-lint": "^5.0.1",
+    "npm-groovy-lint": "^5.0.2",
     "vscode-languageserver-textdocument": "^1.0.1"
   }
 }

--- a/server/src/DocumentsManager.ts
+++ b/server/src/DocumentsManager.ts
@@ -186,6 +186,17 @@ export class DocumentsManager {
 		}
 	}
 
+	// Lint again all open documents (after change of config)
+	async lintAgainAllOpenDocuments() {
+		await this.refreshDebugMode();
+		// Reset all cached document settings
+		this.removeDocumentSettings('all');
+		// Revalidate all open text documents
+		for (const doc of this.documents.all()) {
+			await this.validateTextDocument(doc, { force: true });
+		};
+	}
+
 	// Format a text document
 	async formatTextDocument(textDocument: TextDocument): Promise<TextEdit[]> {
 		return await this.validateTextDocument(textDocument, { format: true });

--- a/server/src/DocumentsManager.ts
+++ b/server/src/DocumentsManager.ts
@@ -75,9 +75,12 @@ export class DocumentsManager {
 		else if (params.command === COMMAND_LINT_FIX.command) {
 			let document: TextDocument = this.getDocumentFromUri(this.currentTextDocumentUri)!;
 			await this.validateTextDocument(document, { fix: true });
-			// Then lint again
-			const newDoc = this.getUpToDateTextDocument(document);
-			this.validateTextDocument(newDoc, { force: true }); // After fix, lint again
+
+			setTimeout(() => { // Wait 500ms so we are more sure that the textDocument is already updated
+				// Then lint again
+				const newDoc = this.getUpToDateTextDocument(document);
+				this.validateTextDocument(newDoc, { force: true }); // After fix, lint again
+			}, 500);
 		}
 		// Command: Apply quick fix
 		else if (params.command === COMMAND_LINT_QUICKFIX.command) {

--- a/server/src/codeActions.ts
+++ b/server/src/codeActions.ts
@@ -388,6 +388,9 @@ export async function disableErrorForProject(diagnostic: Diagnostic, textDocumen
 	const removeAll = true;
 	docManager.removeDiagnostics([diagnostic], textDocument.uri, removeAll);
 
+	// Lint again all open documents
+	docManager.lintAgainAllOpenDocuments();
+
 	// Show message to user and propose to open the configuration file
 	const msg: ShowMessageRequestParams = {
 		type: MessageType.Info,

--- a/server/src/codeActions.ts
+++ b/server/src/codeActions.ts
@@ -212,19 +212,22 @@ export async function applyQuickFixes(diagnostics: Diagnostic[], textDocumentUri
 	const { fixFailures } = parseLinterResults(docLinter.lintResult, textDocument.getText(), textDocument, docManager);
 	// Notify user of failures if existing
 	await notifyFixFailures(fixFailures, docManager);
-	if (docLinter.status === 0) {
-		// Apply updates to textDocument
-		await applyTextDocumentEditOnWorkspace(docManager, textDocument, getUpdatedSource(docLinter, textDocument.getText()));
-		docManager.validateTextDocument(textDocument, { force: true });
-	}
-	// Just Notify client of end of linting 
-	docManager.connection.sendNotification(StatusNotification.type, {
+	// Just Notify client of end of fixing 
+	await docManager.connection.sendNotification(StatusNotification.type, {
 		state: 'lint.end',
 		documents: [{
 			documentUri: textDocument.uri
 		}],
 		lastFileName: textDocument.uri
 	});
+	// Apply updates to textDocument
+	if (docLinter.status === 0) {
+		await applyTextDocumentEditOnWorkspace(docManager, textDocument, getUpdatedSource(docLinter, textDocument.getText()));
+		setTimeout(() => { // Wait 500ms so we are more sure that the textDocument is already updated
+			const newDoc = docManager.getUpToDateTextDocument(textDocument);
+			docManager.validateTextDocument(newDoc, { force: true });
+		}, 500);
+	}
 	debug(`End fixing ${textDocument.uri}`);
 }
 
@@ -243,7 +246,10 @@ export async function applyQuickFixesInFile(diagnostics: Diagnostic[], textDocum
 	await docManager.validateTextDocument(textDocument, { fix: true, fixrules: [fixRule] });
 	// Lint after call
 	debug(`Request new lint of ${textDocumentUri} after fix action`);
-	docManager.validateTextDocument(textDocument);
+	setTimeout(() => { // Wait 500ms so we are more sure that the textDocument is already updated
+		const newDoc = docManager.getUpToDateTextDocument(textDocument);
+		docManager.validateTextDocument(newDoc, { force: true });
+	}, 500);
 }
 
 // Disable error with comment groovylint-disable

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -76,13 +76,7 @@ connection.onExit(async () => {
 // wait N seconds in case a new config change arrive, run just after the last one
 connection.onDidChangeConfiguration(async (change) => {
     debug(`change configuration event received: lint again all open documents`);
-    await docManager.refreshDebugMode();
-    // Reset all cached document settings
-    docManager.removeDocumentSettings('all');
-    // Revalidate all open text documents
-    for (const doc of docManager.documents.all()) {
-        await docManager.validateTextDocument(doc);
-    };
+    await docManager.lintAgainAllOpenDocuments();
 });
 
 // Handle command requests from client


### PR DESCRIPTION
- Fixes
  - When a rule is ignored for all project (updating .groovylintrc.json), lint again all open documents ( Closes #48 )
  - Setting `groovyLint.fix.trigger` was not updateable  (Closes #47 )
  - After applying a QuickFix, wait for the text to be updated to trigger a new code analysis
  - Better catch and display of fatal errors

- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v5.0.2
  - Avoid to apply wrong fix in case of CodeNarc false positive
  - New fix rules
    - BlankLineBeforePackage
  - Updated fix rules
    - BracesForIfElse
    - BracesForMethod
    - BracesForTryCatchFinally
    - ClassEndsWithBlankLine
    - ClassStartsWithBlankLine
    - MissingBlankLineAfterImports
    - MissingBlankLineAfterPackage
    - UnnecessaryGroovyImport
    - UnusedImport