### PR TITLE
Java 12- 13 - 14 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,5 +89,6 @@
       jobs:
         - debian_jdk8
         - debian_jdk11
+        - debian_jdk13
         - windows # Disable if CircleCI reached limit of free plan
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.16.4] 2020-06-04
+
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v5.1.0
+  - Install Java 8 using node-jre in case java version found is higher than Java 11 (CodeNarc compatibility is Java 8 to 11)
+
 ## [0.16.3] 2020-05-30
 
 - Fixes

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ Please follow [Contribution instructions](https://github.com/nvuillam/vscode-gro
 
 ## Release Notes
 
+## [0.16.4] 2020-06-04
+
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v5.1.0
+  - Install Java 8 using node-jre in case java version found is higher than Java 11 (CodeNarc compatibility is Java 8 to 11)
+
 ### [0.16.3] 2020-05-30
 
 - Fixes

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -466,9 +466,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "npm-groovy-lint": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-5.0.3.tgz",
-      "integrity": "sha512-aipw7+gqFracOqR/G4F01xgJOS+KDKvl4IEtTibc8XYeZNdDJCfliE7I3BsobrgzXhpY9wp61iAM9/1wfdSdDA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-5.1.0.tgz",
+      "integrity": "sha512-ocSMdhA9osgDEtb5v4ssv9zCJenSxVb9Oq//+cGuroYXUd0S0xMYdaw10/KD78eCrBtKRFOugFiwHnU+CQWyDw==",
       "dev": true,
       "requires": {
         "@analytics/segment": "^0.4.0",

--- a/server/package.json
+++ b/server/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",
-    "npm-groovy-lint": "^5.0.3",
+    "npm-groovy-lint": "^5.1.0",
     "vscode-languageserver-textdocument": "^1.0.1"
   }
 }


### PR DESCRIPTION
- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v5.1.0
  - Install Java 8 using node-jre in case java version found is higher than Java 11 (CodeNarc compatibility is Java 8 to 11)

- Add tests on JDK13 on CircleCI