### PR TITLE
Override java VM & EOL fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.18.0] 2020-07-12
+
+- New settings **groovyLint.java.executable** and **groovyLint.java.options**
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v5.5.0
+  - Allow to override java executable and options [(#54)](https://github.com/nvuillam/vscode-groovy-lint/issues/54)
+  - Use os.EOL [(#65)](https://github.com/nvuillam/npm-groovy-lint/pull/65) solving  [(#63)](https://github.com/nvuillam/npm-groovy-lint/issues/63) --fix for indentation adds CRLF line-endings to all files it touches
+  
 ## [0.17.1] 2020-07-05
 
 Fixes:

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ Formatting and Auto-fix are still in beta version, please post an [issue](https:
 | `groovyLint.fix.trigger`         | Run the fixer on save (onSave), or on user request                                              | user             |
 | `groovyLint.basic.loglevel`      | Linting error level (error, warning,info)                                                       | info             |
 | `groovyLint.basic.verbose`       | Turn on to have verbose logs                                                                    | false            |
-| `groovyLint.basic.config`        | [NPM groovy lint configuration file](https://github.com/nvuillam/npm-groovy-lint#configuration) | .groovylintrc.js |
+| `groovyLint.basic.config`        | [NPM groovy lint configuration file](https://github.com/nvuillam/npm-groovy-lint#configuration) | .groovylintrc.json |
 | `groovyLint.debug.enable`        | Display more logs in VsCode Output panel (select "GroovyLint") for issue investigation          | false            |
+| `groovyLint.java.executable`     | Override java executable to use <br/>Example: C:\\Program Files\\Java\\jdk1.8.0_144\\bin\\java.exe          | java            |
+| `groovyLint.java.options`        | Override java options to use                                                                    | "-Xms256m,-Xmx2048m"            |
 | `groovyLint.insight.enable`      | Allow to send anonymous usage statistics used only to improve the tool (we will of course never send your code)   | true            |
 
 ## Troubleshooting
@@ -77,7 +79,14 @@ Please follow [Contribution instructions](https://github.com/nvuillam/vscode-gro
 
 ## Release Notes
 
-## [0.17.1] 2020-07-05
+### [0.18.0] 2020-07-12
+
+- New settings **groovyLint.java.executable** and **groovyLint.java.options**
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v5.5.0
+  - Allow to override java executable and options [(#54)](https://github.com/nvuillam/vscode-groovy-lint/issues/54)
+  - Use os.EOL [(#65)](https://github.com/nvuillam/npm-groovy-lint/pull/65) solving  [(#63)](https://github.com/nvuillam/npm-groovy-lint/issues/63) --fix for indentation adds CRLF line-endings to all files it touches
+
+### [0.17.1] 2020-07-05
 
 Fixes:
 

--- a/package-json-schema.json
+++ b/package-json-schema.json
@@ -1,5 +1,5 @@
 {
-	"title": "JSON schema for ESLint configuration files",
+	"title": "JSON schema for GroovyLint configuration files",
 	"$schema": "http://json-schema.org/draft-04/schema#",
 	"type": "object",
 	"definitions": {

--- a/package.json
+++ b/package.json
@@ -255,6 +255,16 @@
 					"default": false,
 					"description": "Display debugging info in output panel"
 				},
+				"groovyLint.java.executable": {
+					"scope": "resource",
+					"type": "string",
+					"description": "Path to java executable if you do not want to use system default"
+				},
+				"groovyLint.java.options": {
+					"scope": "resource",
+					"type": "string",
+					"description": "Comma separated arguments for java (default \"-Xms256m,-Xmx2048m\")"
+				},
 				"groovyLint.insight.enable": {
 					"scope": "resource",
 					"type": "boolean",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -306,9 +306,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "npm-groovy-lint": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-5.4.1.tgz",
-      "integrity": "sha512-TxenKN40k8jenMcWijH5vVX+LMuYgLt2K8OwqBXDlSaKU0fH6ZTCbnvbPlzo7CUkUVegEONwi3kjsr2d9Ufnkw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-5.5.0.tgz",
+      "integrity": "sha512-r95/ZtmbM+BDDL/xfVSjsQNZlQKlPtC1PnQnWBjXtTecd7rhd476Q+G1VbqxU+pVAbgzh0i28iD2snFm6zd+Zw==",
       "dev": true,
       "requires": {
         "@amplitude/node": "^0.3.3",

--- a/server/package.json
+++ b/server/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",
-    "npm-groovy-lint": "^5.4.1",
+    "npm-groovy-lint": "^5.5.0",
     "vscode-languageserver-textdocument": "^1.0.1"
   }
 }

--- a/server/src/clientUtils.ts
+++ b/server/src/clientUtils.ts
@@ -3,6 +3,7 @@ import { TextDocumentEdit, WorkspaceEdit, ShowMessageRequestParams, MessageType,
 import { DocumentsManager } from './DocumentsManager';
 import { OpenNotification } from './types';
 const debug = require("debug")("vscode-groovy-lint");
+import os = require("os");
 
 const defaultDocUrl = "https://codenarc.github.io/CodeNarc/codenarc-rule-index.html";
 
@@ -37,7 +38,7 @@ export function createTextEdit(docManager: DocumentsManager, textDocument: TextD
 				start: { line: 0, character: 0 },
 				end: { line: allLines.length - 1, character: allLines[allLines.length - 1].length }
 			},
-			newText: allLines.join('\r\n')
+			newText: allLines.join(os.EOL)
 		};
 	}
 	// Replace line at position

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -155,6 +155,13 @@ export async function executeLinter(textDocument: TextDocument, docManager: Docu
 		npmGroovyLintConfig.rulesetsoverridetype = "appendConfig";
 	}
 
+	// Java & options override
+	if (settings.java.executable) {
+		npmGroovyLintConfig.javaexecutable = settings.java.executable;
+	}
+	if (settings.java.options) {
+		npmGroovyLintConfig.javaoptions = settings.java.options;
+	}
 
 	// If source has not changed, do not lint again
 	if (isSimpleLintIdenticalSource === true) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -75,7 +75,9 @@ connection.onExit(async () => {
 // Lint again all opened documents in configuration changed 
 // wait N seconds in case a new config change arrive, run just after the last one
 connection.onDidChangeConfiguration(async (change) => {
-    debug(`change configuration event received: lint again all open documents`);
+    debug(`change configuration event received: restart server and lint again all open documents`);
+    await new NpmGroovyLint({ killserver: true }, {}).run();
+    await docManager.cancelAllDocumentValidations();
     await docManager.lintAgainAllOpenDocuments();
 });
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -44,6 +44,7 @@ export interface VsCodeGroovyLintSettings {
 	fix?: any;
 	format?: any;
 	basic?: any;
+	java?: any
 	insight?: any;
 	tabSize?: number;
 }


### PR DESCRIPTION
- New settings **groovyLint.java.executable** and **groovyLint.java.options**
- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v5.5.0
  - Allow to override java executable and options [(#54)](https://github.com/nvuillam/vscode-groovy-lint/issues/54)
  - Use os.EOL [(#65)](https://github.com/nvuillam/npm-groovy-lint/pull/65) solving  [(#63)](https://github.com/nvuillam/npm-groovy-lint/issues/63) --fix for indentation adds CRLF line-endings to all files it touches

Closes #54 