### PR TITLE
Upgrade to npm-groovy-lint 7.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.2.0] 2020-08-15
+
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v7.3.0
+  - Allow to link to [CodeNarc RuleSet files](https://codenarc.github.io/CodeNarc/codenarc-creating-ruleset.html) from `.groovylintrc.json`, using property `"codenarcRulesets"`. Warning: doing so means that all other properties of config file will be ignored.
+
 ## [1.1.1] 2020-08-11
 
 - Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v7.2.0

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ Please follow [Contribution instructions](https://github.com/nvuillam/vscode-gro
 
 ## Release Notes
 
+### [1.2.0] 2020-08-15
+
+- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v7.3.0
+  - Allow to link to [CodeNarc RuleSet files](https://codenarc.github.io/CodeNarc/codenarc-creating-ruleset.html) from `.groovylintrc.json`, using property `"codenarcRulesets"`. Warning: doing so means that all other properties of config file will be ignored.
+
 ### [1.1.1] 2020-08-11
 
 - Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v7.2.0

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -284,9 +284,9 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "java-caller": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/java-caller/-/java-caller-2.0.0.tgz",
-      "integrity": "sha512-oSv2BCo1zZWo1Q6t01Bs1Gef4NXv36Rbu39n2M9vQ5Iacsopplx9ik38gfeHp4vLMuvOTVlTEnl9uAU+g3rzlA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/java-caller/-/java-caller-2.1.0.tgz",
+      "integrity": "sha512-akhcPM1YKmOWoVaNnAh0rrlyWkESa+tU9E1GxfdyotDVMe6r2w/gBJUaTmngihRbYL4QwA3NB3pu7x7sq2YH8g==",
       "requires": {
         "debug": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -397,9 +397,9 @@
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "npm-groovy-lint": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-7.2.0.tgz",
-      "integrity": "sha512-USoW673L/+0/rj+kKmLPVjCtsW5Izi4T0N4ov3wjdamdeUy67/kH1VawaHiB+F3lEPjVpnkOtUDrzn3mQw5bbQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-7.3.0.tgz",
+      "integrity": "sha512-kmNVHcI5DEEU3KiU7Vuk0ZMGp9F3Ux+KzAWcK/djKAeLXNSVx6eu5HDVNw/5vv4fk6O4NllQDlGauGIyKy6xLw==",
       "requires": {
         "@amplitude/node": "^0.3.3",
         "ansi-colors": "^4.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -34,7 +34,7 @@
     "find-java-home": "^1.1.0",
     "fs-extra": "^8.1.0",
     "glob-promise": "^3.4.0",
-    "npm-groovy-lint": "^7.2.0",
+    "npm-groovy-lint": "^7.3.0",
     "vscode-languageserver": "^6.1.1",
     "vscode-uri": "^2.1.1"
   },


### PR DESCRIPTION
- Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v7.3.0
  - Allow to link to [CodeNarc RuleSet files](https://codenarc.github.io/CodeNarc/codenarc-creating-ruleset.html) from `.groovylintrc.json`, using property `"codenarcRulesets"`. Warning: doing so means that all other properties of config file will be ignored.

Closes #68 