### PR TITLE
Fix crash when no results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Write your updates here !
 
+## [1.7.5] 2022-01-26
+
+- Fix crash when npm-groovy-lint does not return results ([#141](https://github.com/nvuillam/vscode-groovy-lint/issues/141))
+
 ## [1.7.4] 2022-01-09
 
 - Upgrade to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v9.3.2

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -207,9 +207,9 @@
       "integrity": "sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw=="
     },
     "follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "fs-extra": {
       "version": "8.1.0",

--- a/server/src/linterParser.ts
+++ b/server/src/linterParser.ts
@@ -14,8 +14,8 @@ export function parseLinterResults(lintResults: any, source: string, textDocumen
 	let diagnostics: Diagnostic[] = [];
 	const fixFailures: any[] = [];
 	const docQuickFixes: any = {};
-	debug(`Parsing results of ${textDocument.uri} (${Object.keys(lintResults.files).length} in lintResults)`);
-	if (lintResults.files && lintResults.files[0] && lintResults.files[0].errors) {
+	if (lintResults?.files && lintResults.files[0] && lintResults.files[0].errors) {
+		debug(`Parsing results of ${textDocument.uri} (${Object.keys(lintResults.files).length} in lintResults)`);
 		// Get each error for the file
 		let pos = 0;
 		for (const err of lintResults.files[0].errors) {


### PR DESCRIPTION
- Fix crash when npm-groovy-lint does not return results ([#141](https://github.com/nvuillam/vscode-groovy-lint/issues/141))