### PR TITLE
fix: Analyze Groovy files in folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Write your updates here !
+- Fix Analyze Groovy files in folder ([#177](https://github.com/nvuillam/vscode-groovy-lint/issues/177))
 
 ## [2.0.0] 2022-08-13
 

--- a/package.json
+++ b/package.json
@@ -138,6 +138,10 @@
         {
           "when": "resourceLangId == groovy || resourceLangId == jenkinsfile",
           "command": "groovyLint.lintFix"
+        },
+        {
+          "when": "filesExplorerFocus && explorerResourceIsFolder",
+          "command": "groovyLint.lintFolder"
         }
       ],
       "editor/context": [
@@ -155,7 +159,8 @@
       "explorer/context": [
         {
           "command": "groovyLint.lintFolder",
-          "group": "groovylint"
+          "group": "groovylint",
+          "when": "filesExplorerFocus && explorerResourceIsFolder"
         }
       ]
     },
@@ -176,7 +181,7 @@
         "command": "groovyLint.lintFolder",
         "key": "ctrl+shift+F11",
         "mac": "cmd+shift+F11",
-        "when": "explorerResourceIsFolder"
+        "when": "filesExplorerFocus && explorerResourceIsFolder"
       }
     ],
     "configuration": {

--- a/server/src/folder.ts
+++ b/server/src/folder.ts
@@ -17,7 +17,7 @@ export async function lintFolder(folders: Array<any>, docManager: DocumentsManag
 
 	// Function to lint all applicable files of a folder
 	async function processLintFolder() {
-		const folderList = folders.map(fldr => fldr.fsPath);
+		const folderList = folders.map(fldr => fldr.path);
 		debug(`Start analyzing folder(s): ${folderList.join(',')}`);
 		// Browse each folder
 		for (const folder of folderList) {
@@ -63,7 +63,7 @@ export async function lintFolder(folders: Array<any>, docManager: DocumentsManag
 				]
 			};
 			const req = await docManager.connection.sendRequest('window/showMessageRequest', msg);
-			if (req.title === "Cancel lint of folders") {
+			if (req?.title === "Cancel lint of folders") {
 				continueLinting = false;
 			}
 		}


### PR DESCRIPTION
Fix Analyze Groovy files in folder which was always available resulting in failures dependent on the context it was used.

It is now only available from a explorer folder.

Also correct the name of the parameter passed so explorer folder requests work.

Fixes #177
<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the **CHANGELOG.md** listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
