### PR TITLE
fix: partial fixes never applying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Write your updates here !
+- Fix partial fixes never applying due to [npm-groovy-lint](https://www.npmjs.com/package/npm-groovy-lint) v10.0.0 breaking change.
 
 ## [2.0.0] 2022-08-13
 

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -128,7 +128,8 @@ export async function executeLinter(textDocument: TextDocument, docManager: Docu
 		returnrules: docManager.getRuleDescriptions().size > 0 ? false : true,
 		insight: ((settings?.insight?.enable) ? true : false),
 		output: 'none',
-		verbose: settings.basic.verbose
+		verbose: settings.basic.verbose,
+		failon: 'none'
 	};
 
 	const npmGroovyLintExecParam: any = {};
@@ -397,7 +398,8 @@ async function manageFixSourceBeforeCallingLinter(source: string, textDocument: 
 			const textDocumentFilePath: string = URI.parse(textDocument.uri).fsPath;
 			const tmpLinter = new NpmGroovyLint({
 				sourcefilepath: textDocumentFilePath,
-				output: 'none'
+				output: 'none',
+				failon: 'none'
 			}, {});
 			const tmpStartPath = path.dirname(textDocumentFilePath);
 			let tmpConfigFilePath: string = await tmpLinter.getConfigFilePath(tmpStartPath);


### PR DESCRIPTION
Fix fixes in files which still have remaining issues not applying due to the change in behaviour of npm-groovy-lint status code handling in 11.0.0 by now requesting failon: none.

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the **CHANGELOG.md** listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
