### PR TITLE
new settings option to show problems panel after initial pass

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -7,7 +7,7 @@ on:
   # Trigger mega-linter at every push. Action will also be visible from Pull Requests to master
   push: # Comment this line to trigger action only on pull-requests (not recommended if you don't pay for GH Actions)
   pull_request:
-    branches: [master]
+    branches: [main]
 
 env: #Uncomment to activate variables below
   # Apply linter fixes configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix doc deployment
 - Add stale workflow
-- added new setting `showProblemsView` that controls if Problems View should open after initial lint pass
+- Added new setting `showProblemsView` that controls if Problems View should open after initial lint pass
 
 ## [3.0.0] 2023-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix doc deployment
 - Add stale workflow
+- added new setting `showProblemsView` that controls if Problems View should open after initial lint pass
 
 ## [3.0.0] 2023-12-17
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ## Features
 
 | Command                                | Description                                                                                      | Access                                                   |
-|----------------------------------------|--------------------------------------------------------------------------------------------------|----------------------------------------------------------|
+| -------------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
 | **Analyze code**                       | Lint the code of the current file                                                                | Ctrl+Shift+F9<br/>Contextual</br>Status bar<br/>Commands |
 | **Format**                             | Format the code of the current file                                                              | Shift+Alt+F<br/>Contextual</br>Commands                  |
 | **Fix all auto-fixable problems**      | Fix the code of the current file                                                                 | Contextual</br>Commands                                  |
@@ -40,20 +40,21 @@
 
 ## Extension Settings
 
-| Parameter                    | Description                                                                                                     | Default              |
-|------------------------------|-----------------------------------------------------------------------------------------------------------------|----------------------|
-| `groovyLint.enable`          | Controls whether GroovyLint is enabled or not                                                                   | true                 |
-| `groovyLint.lint.trigger`    | Run the linter on save (onSave), on type (onType) , or on user request                                          | onSave               |
-| `groovyLint.format.enable`   | Controls whether the groovy formatter is enabled or not                                                         | true                 |
-| `groovyLint.fix.enable`      | Run the auto-fixer on save (onSave), on type (onType) , or on user request                                      | true                 |
-| `groovyLint.fix.trigger`     | Run the fixer on save (onSave), or on user request                                                              | user                 |
-| `groovyLint.basic.loglevel`  | Linting error level (error, warning,info)                                                                       | info                 |
-| `groovyLint.basic.verbose`   | Turn on to have verbose logs                                                                                    | false                |
-| `groovyLint.basic.config`    | [NPM groovy lint configuration file](https://github.com/nvuillam/npm-groovy-lint#configuration)                 | .groovylintrc.json   |
-| `groovyLint.debug.enable`    | Display more logs in VsCode Output panel (select "GroovyLint") for issue investigation                          | false                |
-| `groovyLint.java.executable` | Override java executable to use <br/>Example: C:\\Program Files\\Java\\jdk1.8.0_144\\bin\\java.exe              | java                 |
-| `groovyLint.java.options`    | Override java options to use                                                                                    | "-Xms256m,-Xmx2048m" |
-| `groovyLint.insight.enable`  | Allow to send anonymous usage statistics used only to improve the tool (we will of course never send your code) | false                |
+| Parameter                     | Description                                                                                                     | Default              |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `groovyLint.enable`           | Controls whether GroovyLint is enabled or not                                                                   | true                 |
+| `groovyLint.lint.trigger`     | Run the linter on save (onSave), on type (onType) , or on user request                                          | onSave               |
+| `groovyLint.format.enable`    | Controls whether the groovy formatter is enabled or not                                                         | true                 |
+| `groovyLint.fix.enable`       | Run the auto-fixer on save (onSave), on type (onType) , or on user request                                      | true                 |
+| `groovyLint.fix.trigger`      | Run the fixer on save (onSave), or on user request                                                              | user                 |
+| `groovyLint.basic.loglevel`   | Linting error level (error, warning,info)                                                                       | info                 |
+| `groovyLint.basic.verbose`    | Turn on to have verbose logs                                                                                    | false                |
+| `groovyLint.basic.config`     | [NPM groovy lint configuration file](https://github.com/nvuillam/npm-groovy-lint#configuration)                 | .groovylintrc.json   |
+| `groovyLint.debug.enable`     | Display more logs in VsCode Output panel (select "GroovyLint") for issue investigation                          | false                |
+| `groovyLint.java.executable`  | Override java executable to use <br/>Example: C:\\Program Files\\Java\\jdk1.8.0_144\\bin\\java.exe              | java                 |
+| `groovyLint.java.options`     | Override java options to use                                                                                    | "-Xms256m,-Xmx2048m" |
+| `groovyLint.insight.enable`   | Allow to send anonymous usage statistics used only to improve the tool (we will of course never send your code) | false                |
+| `groovyLint.showProblemsView` | Show Problems View once after start                                                                             | false                |
 
 ## Troubleshooting
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -152,8 +152,7 @@ async function updateStatus(status: StatusParams): Promise<any> {
 		statusList = statusList.filter(statusObj => statusObj.id !== status.id);
 
 		// Show Problems panel just once (if user didn't choose otherwise)
-		const showProblems = workspace.getConfiguration('groovyLint').get('showProblemsView', true);
-		if (showProblems && outputChannelShowedOnce === false) {
+		if (outputChannelShowedOnce === false && vscode.workspace.getConfiguration('groovyLint').get('showProblemsView', true) === true) {
 			vscode.commands.executeCommand('workbench.panel.markers.view.focus');
 			outputChannelShowedOnce = true;
 		}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -150,8 +150,10 @@ async function updateStatus(status: StatusParams): Promise<any> {
 	else if (status.state.startsWith('lint.end')) {
 		// Update status list
 		statusList = statusList.filter(statusObj => statusObj.id !== status.id);
-		// Show markers panel just once (after the user can choose to close it)
-		if (outputChannelShowedOnce === false) {
+
+		// Show Problems panel just once (if user didn't choose otherwise)
+		const showProblems = workspace.getConfiguration('groovyLint').get('showProblemsView', true);
+		if (showProblems && outputChannelShowedOnce === false) {
 			vscode.commands.executeCommand('workbench.panel.markers.view.focus');
 			outputChannelShowedOnce = true;
 		}

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@
 ## Features
 
 | Command                                | Description                                                                                      | Access                                                   |
-|----------------------------------------|--------------------------------------------------------------------------------------------------|----------------------------------------------------------|
+| -------------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
 | **Analyze code**                       | Lint the code of the current file                                                                | Ctrl+Shift+F9<br/>Contextual</br>Status bar<br/>Commands |
 | **Format**                             | Format the code of the current file                                                              | Shift+Alt+F<br/>Contextual</br>Commands                  |
 | **Fix all auto-fixable problems**      | Fix the code of the current file                                                                 | Contextual</br>Commands                                  |
@@ -40,20 +40,21 @@
 
 ## Extension Settings
 
-| Parameter                    | Description                                                                                                     | Default              |
-|------------------------------|-----------------------------------------------------------------------------------------------------------------|----------------------|
-| `groovyLint.enable`          | Controls whether GroovyLint is enabled or not                                                                   | true                 |
-| `groovyLint.lint.trigger`    | Run the linter on save (onSave), on type (onType) , or on user request                                          | onSave               |
-| `groovyLint.format.enable`   | Controls whether the groovy formatter is enabled or not                                                         | true                 |
-| `groovyLint.fix.enable`      | Run the auto-fixer on save (onSave), on type (onType) , or on user request                                      | true                 |
-| `groovyLint.fix.trigger`     | Run the fixer on save (onSave), or on user request                                                              | user                 |
-| `groovyLint.basic.loglevel`  | Linting error level (error, warning,info)                                                                       | info                 |
-| `groovyLint.basic.verbose`   | Turn on to have verbose logs                                                                                    | false                |
-| `groovyLint.basic.config`    | [NPM groovy lint configuration file](https://github.com/nvuillam/npm-groovy-lint#configuration)                 | .groovylintrc.json   |
-| `groovyLint.debug.enable`    | Display more logs in VsCode Output panel (select "GroovyLint") for issue investigation                          | false                |
-| `groovyLint.java.executable` | Override java executable to use <br/>Example: C:\\Program Files\\Java\\jdk1.8.0_144\\bin\\java.exe              | java                 |
-| `groovyLint.java.options`    | Override java options to use                                                                                    | "-Xms256m,-Xmx2048m" |
-| `groovyLint.insight.enable`  | Allow to send anonymous usage statistics used only to improve the tool (we will of course never send your code) | false                |
+| Parameter                     | Description                                                                                                     | Default              |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `groovyLint.enable`           | Controls whether GroovyLint is enabled or not                                                                   | true                 |
+| `groovyLint.lint.trigger`     | Run the linter on save (onSave), on type (onType) , or on user request                                          | onSave               |
+| `groovyLint.format.enable`    | Controls whether the groovy formatter is enabled or not                                                         | true                 |
+| `groovyLint.fix.enable`       | Run the auto-fixer on save (onSave), on type (onType) , or on user request                                      | true                 |
+| `groovyLint.fix.trigger`      | Run the fixer on save (onSave), or on user request                                                              | user                 |
+| `groovyLint.basic.loglevel`   | Linting error level (error, warning,info)                                                                       | info                 |
+| `groovyLint.basic.verbose`    | Turn on to have verbose logs                                                                                    | false                |
+| `groovyLint.basic.config`     | [NPM groovy lint configuration file](https://github.com/nvuillam/npm-groovy-lint#configuration)                 | .groovylintrc.json   |
+| `groovyLint.debug.enable`     | Display more logs in VsCode Output panel (select "GroovyLint") for issue investigation                          | false                |
+| `groovyLint.java.executable`  | Override java executable to use <br/>Example: C:\\Program Files\\Java\\jdk1.8.0_144\\bin\\java.exe              | java                 |
+| `groovyLint.java.options`     | Override java options to use                                                                                    | "-Xms256m,-Xmx2048m" |
+| `groovyLint.insight.enable`   | Allow to send anonymous usage statistics used only to improve the tool (we will of course never send your code) | false                |
+| `groovyLint.showProblemsView` | Show Problems View once after start                                                                             | false                |
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -191,6 +191,12 @@
           "default": true,
           "description": "Controls whether GroovyLint is enabled or not."
         },
+        "groovyLint.showProblemsView": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "description": "Show Problems View once after start."
+        },
         "groovyLint.lint.trigger": {
           "scope": "resource",
           "type": "string",


### PR DESCRIPTION
## Proposed Changes

1. new settings option `showProblemsView` to control if Problems View should be opened after initial lint pass

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the **CHANGELOG.md** listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
