### PR TITLE
Updates publish workflow to Node.js 24

### DIFF
--- a/.github/workflows/deploy-RELEASE.yml
+++ b/.github/workflows/deploy-RELEASE.yml
@@ -20,6 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - run: npm ci
       - uses: lannonbr/vsce-action@510e61c5e9e6f33c0418ec5ff5fd36b1ced61e85
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Use Node24 in publish workflow
+
 ## [4.2.0] 2026-03-01
 
 - New minimum NodeJs version: 22


### PR DESCRIPTION
Ensures the release deployment process utilizes Node.js version 24. This helps maintain compatibility with modern tools and dependencies, improving the reliability and security of the publishing pipeline.
