### PR TITLE
Fix #343: preserve diff/compare view when lint triggers on edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Migrate to ESLint flat config
 - Upgrade dependencies
 - CI improvements and security hardening
+- Fix: preserve diff/compare view when lint triggers on edit ([#343](https://github.com/nvuillam/vscode-groovy-lint/issues/343))
 
 ## [4.2.1] 2026-04-15
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -140,6 +140,11 @@ async function updateStatus(status: StatusParams): Promise<any> {
 		statusList.push(status);
 		// Really open document previewed documents, so tab will not be replaced by next preview
 		for (const docDef of status.documents) {
+			// Skip if the document is currently displayed in a diff/compare editor to avoid
+			// moving the user out of the diff view into the regular file tab
+			if (isDocumentInDiffEditor(docDef.documentUri)) {
+				continue;
+			}
 			const documentTextEditors = vscode.window.visibleTextEditors.filter(txtDoc => txtDoc.document.uri.toString() === docDef.documentUri);
 			if (documentTextEditors && documentTextEditors[0]) {
 				await vscode.window.showTextDocument(documentTextEditors[0].document, { preview: false, preserveFocus: true });
@@ -171,6 +176,20 @@ async function updateStatus(status: StatusParams): Promise<any> {
 	}
 	// Refresh status bar content (icon + tooltip)
 	await refreshStatusBar();
+}
+
+// Check if a document URI is currently open in a diff/compare editor
+function isDocumentInDiffEditor(docUri: string): boolean {
+	for (const tabGroup of vscode.window.tabGroups.all) {
+		for (const tab of tabGroup.tabs) {
+			if (tab.input instanceof vscode.TabInputTextDiff) {
+				if (tab.input.modified.toString() === docUri || tab.input.original.toString() === docUri) {
+					return true;
+				}
+			}
+		}
+	}
+	return false;
 }
 
 // Get URI from StatusParams


### PR DESCRIPTION
## Description

When editing a Groovy file in a diff/compare editor (e.g. Compare with Clipboard, Compare with Selected), the lint startup routine was calling `showTextDocument()` with `preview: false` for the document being linted (`client/src/extension.ts:142-147`). This moved the user out of the diff view into the regular file tab.

## Fix

Added `isDocumentInDiffEditor()` helper that checks all tab groups for `TabInputTextDiff` entries containing the document URI. When detected, the `showTextDocument` call is skipped, preserving the diff/compare view.

## Related issue

Closes #343